### PR TITLE
ci: add a container job to the matrix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,9 +77,11 @@ jobs:
             target: macos
           # Using the `ubuntu-18.04` runner instead of latest (i.e. `ubuntu-22.04`)
           # because G++/GCC 4.8 is not in an official repository yet.
-          - os: ubuntu-18.04
+          - os: ubuntu-22.04
             target: linux
+            container: ubuntu:18.04
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Ubuntu 18 is no longer supported starting from the April. Please refer to the article for the details: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

relates-to: actions/runner-images#7388