### PR TITLE
feat(request-executor): support `deflate` encoding without `zlib` headers

### DIFF
--- a/src/RequestExecutor/HttpRequestExecutor.ts
+++ b/src/RequestExecutor/HttpRequestExecutor.ts
@@ -5,6 +5,7 @@ import { logger } from '../Utils';
 import { VirtualScripts } from '../Scripts';
 import { Protocol } from './Protocol';
 import { RequestExecutorOptions } from './RequestExecutorOptions';
+import { NormalizeZlibDeflateTransformStream } from '../Utils/NormalizeZlibDeflateTransformStream';
 import { SocksProxyAgent } from 'socks-proxy-agent';
 import { inject, injectable } from 'tsyringe';
 import { parse as parseMimetype } from 'content-type';
@@ -245,7 +246,9 @@ export class HttpRequestExecutor implements RequestExecutor {
           body = response.pipe(createGunzip(zlibOptions));
           break;
         case 'deflate':
-          body = response.pipe(createInflate(zlibOptions));
+          body = response
+            .pipe(new NormalizeZlibDeflateTransformStream())
+            .pipe(createInflate(zlibOptions));
           break;
         case 'br':
           body = response.pipe(createBrotliDecompress());

--- a/src/Utils/NormalizeZlibDeflateTransformStream.spec.ts
+++ b/src/Utils/NormalizeZlibDeflateTransformStream.spec.ts
@@ -1,0 +1,54 @@
+import { NormalizeZlibDeflateTransformStream } from './NormalizeZlibDeflateTransformStream';
+import { promisify } from 'util';
+import { constants, createInflate, deflate, deflateRaw } from 'zlib';
+import { Readable } from 'stream';
+
+const zOpts = {
+  flush: constants.Z_SYNC_FLUSH,
+  finishFlush: constants.Z_SYNC_FLUSH
+};
+
+// TODO: replace with Readable.from once support for Node 10 is dropped
+const readableFrom = (buffer: Buffer) => {
+  const stream = new Readable();
+  stream.push(buffer);
+  stream.push(null);
+
+  return stream;
+};
+
+describe('NormalizeZlibDeflateTransformStream', () => {
+  it('should add zlib headers to raw deflate', async () => {
+    // arrange
+    const data = 'xyz'.repeat(200);
+
+    const stream = readableFrom(await promisify(deflateRaw)(data, zOpts));
+    // act
+    const inflated = stream
+      .pipe(new NormalizeZlibDeflateTransformStream())
+      .pipe(createInflate(zOpts));
+    // assert
+    const result = [];
+    for await (const chunk of inflated) {
+      result.push(chunk);
+    }
+    expect(result.join('')).toBe(data);
+  });
+
+  it('should not affect deflate with zlib headers', async () => {
+    // arrange
+    const data = 'xyz'.repeat(200);
+
+    const stream = readableFrom(await promisify(deflate)(data, zOpts));
+    // act
+    const inflated = stream
+      .pipe(new NormalizeZlibDeflateTransformStream())
+      .pipe(createInflate(zOpts));
+    // assert
+    const result = [];
+    for await (const chunk of inflated) {
+      result.push(chunk);
+    }
+    expect(result.join('')).toBe(data);
+  });
+});

--- a/src/Utils/NormalizeZlibDeflateTransformStream.ts
+++ b/src/Utils/NormalizeZlibDeflateTransformStream.ts
@@ -1,0 +1,23 @@
+import { Transform, TransformCallback } from 'stream';
+
+export class NormalizeZlibDeflateTransformStream extends Transform {
+  private hasCheckedHead = false;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public _transform(
+    chunk: any,
+    encoding: BufferEncoding,
+    callback: TransformCallback
+  ) {
+    if (!this.hasCheckedHead && chunk.length !== 0) {
+      // ADHOC: detects raw deflate: https://stackoverflow.com/a/37528114
+      if (chunk[0] !== 0x78) {
+        const header = Buffer.from([0x78, 0x9c]);
+        this.push(header, encoding);
+      }
+      this.hasCheckedHead = true;
+    }
+
+    this.push(chunk, encoding);
+    callback();
+  }
+}

--- a/src/Utils/NormalizeZlibDeflateTransformStream.ts
+++ b/src/Utils/NormalizeZlibDeflateTransformStream.ts
@@ -2,6 +2,7 @@ import { Transform, TransformCallback } from 'stream';
 
 export class NormalizeZlibDeflateTransformStream extends Transform {
   private hasCheckedHead = false;
+  private readonly header = Buffer.from([0x78, 0x9c]);
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public _transform(
     chunk: any,
@@ -10,9 +11,8 @@ export class NormalizeZlibDeflateTransformStream extends Transform {
   ) {
     if (!this.hasCheckedHead && chunk.length !== 0) {
       // ADHOC: detects raw deflate: https://stackoverflow.com/a/37528114
-      if (chunk[0] !== 0x78) {
-        const header = Buffer.from([0x78, 0x9c]);
-        this.push(header, encoding);
+      if (chunk.compare(this.header, 0, 1, 0, 1) !== 0) {
+        this.push(this.header, encoding);
       }
       this.hasCheckedHead = true;
     }


### PR DESCRIPTION
closes #409