### PR TITLE
refactor(sentry): capture formatted messages

### DIFF
--- a/src/Utils/Logger.ts
+++ b/src/Utils/Logger.ts
@@ -49,7 +49,10 @@ export class Logger {
     let message: string;
 
     if (typeof errorOrMessage === 'string') {
-      args.unshift(messageOrArg);
+      if (arguments.length > 1) {
+        args.unshift(messageOrArg);
+      }
+
       message = errorOrMessage;
       const formattedMessage = format(message, ...args);
 

--- a/src/Utils/Logger.ts
+++ b/src/Utils/Logger.ts
@@ -58,7 +58,6 @@ export class Logger {
 
       captureMessage(formattedMessage, {
         ...captureContext,
-        fingerprint: [formattedMessage],
         level: 'error'
       });
     } else {

--- a/src/Utils/Logger.ts
+++ b/src/Utils/Logger.ts
@@ -51,10 +51,11 @@ export class Logger {
     if (typeof errorOrMessage === 'string') {
       args.unshift(messageOrArg);
       message = errorOrMessage;
+      const formattedMessage = format(message, ...args);
 
-      captureMessage(message, {
+      captureMessage(formattedMessage, {
         ...captureContext,
-        fingerprint: [message],
+        fingerprint: [formattedMessage],
         level: 'error'
       });
     } else {


### PR DESCRIPTION
Some errors are logged in `printf`-like format, so despite we send all logged arguments to Sentry, the captured message is too generic. At the same time some passed logged arguments are being filtered by Sentry, which makes issue investigation harder.

This commit solves this problem by utilizing `utils.format` function.

relates-to: #458 