### PR TITLE
fix(deps): pin dependencies using `node-gyp-build`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@neuralegion/capture-har": "^0.3.4",
-        "@neuralegion/os-service": "^1.2.2",
-        "@neuralegion/raw-socket": "^1.8.2",
+        "@neuralegion/os-service": "1.2.2",
+        "@neuralegion/raw-socket": "1.8.2",
         "@sentry/node": "^7.70.0",
         "ajv": "^6.12.6",
         "amqplib": "~0.10.2",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@neuralegion/capture-har": "^0.3.4",
-    "@neuralegion/os-service": "^1.2.2",
-    "@neuralegion/raw-socket": "^1.8.2",
+    "@neuralegion/os-service": "1.2.2",
+    "@neuralegion/raw-socket": "1.8.2",
     "@sentry/node": "^7.70.0",
     "ajv": "^6.12.6",
     "amqplib": "~0.10.2",


### PR DESCRIPTION
Prevents potential issues caused by automatic updates to these dependencies