### PR TITLE
docs: deprecated some commands and options

### DIFF
--- a/src/Commands/GenerateArchive.ts
+++ b/src/Commands/GenerateArchive.ts
@@ -13,6 +13,8 @@ import { Har } from 'har-format';
 import { basename } from 'path';
 
 export class GenerateArchive implements CommandModule {
+  public readonly deprecated =
+    'Use "archive:upload" with HAR, OAS or Postman collections';
   public readonly command = 'archive:generate [options] <mockfile>';
   public readonly describe = 'Generates a new archive on base unit-tests.';
 

--- a/src/Commands/Integration.ts
+++ b/src/Commands/Integration.ts
@@ -83,7 +83,7 @@ export class Integration implements CommandModule {
         requiresArg: false,
         hidden: true
       })
-      .conflicts('remove-daemon', 'daemon')
+      .conflicts({ daemon: 'remove-daemon' })
       .middleware((args: Arguments) => {
         container
           .register<IntegrationOptions>(IntegrationOptions, {

--- a/src/Commands/RunRepeater.ts
+++ b/src/Commands/RunRepeater.ts
@@ -63,6 +63,7 @@ export class RunRepeater implements CommandModule {
       })
       .option('headers', {
         requiresArg: true,
+        deprecated: 'Use --header instead.',
         string: true,
         conflicts: ['header'],
         describe:
@@ -115,9 +116,9 @@ export class RunRepeater implements CommandModule {
         }
       })
       .option('experimental-connection-reuse', {
-        deprecate: 'Use --ntlm instead',
+        deprecated: 'Use --ntlm instead',
         boolean: true,
-        describe: 'Configure experimental support for TCP connections reuse'
+        describe: 'Configure ntlm support (enables TCP connection reuse)'
       })
       .option('ntlm', {
         boolean: true,
@@ -138,19 +139,20 @@ export class RunRepeater implements CommandModule {
         describe: 'Stop and remove repeater daemon'
       })
       .option('rabbitmq', {
+        deprecated: true,
         boolean: true,
         describe:
           'Enable legacy mode, utilizing the RabbitMQ connection for communication.'
       })
-      .conflicts('remove-daemon', 'daemon')
-      .conflicts('experimental-connection-reuse', 'proxy')
-      .conflicts('experimental-connection-reuse', 'proxy-external')
-      .conflicts('experimental-connection-reuse', 'proxy-internal')
-      .conflicts('ntlm', 'proxy')
-      .conflicts('ntlm', 'proxy-external')
-      .conflicts('ntlm', 'proxy-internal')
-      .conflicts('proxy-external', 'proxy')
-      .conflicts('proxy-internal', 'proxy')
+      .conflicts({
+        daemon: 'remove-daemon',
+        ntlm: [
+          'proxy',
+          'proxy-external',
+          'proxy-internal',
+          'experimental-connection-reuse'
+        ]
+      })
       .env('REPEATER')
       .middleware((args: Arguments) => {
         if (Object.hasOwnProperty.call(args, '')) {

--- a/src/Commands/UploadArchive.ts
+++ b/src/Commands/UploadArchive.ts
@@ -49,6 +49,8 @@ export class UploadArchive implements CommandModule {
       .option('header', {
         alias: 'H',
         default: [],
+        deprecated:
+          'Use --header when running a scan using the scan:run command.',
         requiresArg: true,
         array: true,
         describe:
@@ -60,6 +62,8 @@ export class UploadArchive implements CommandModule {
       .option('variable', {
         alias: 'V',
         default: [],
+        deprecated:
+          'Directly integrate variables into the file. For updated guidelines on managing variables effectively, refer to https://learning.postman.com/docs/sending-requests/variables/variables/#variable-scopes',
         requiresArg: true,
         array: true,
         describe:

--- a/src/Config/CliBuilder.ts
+++ b/src/Config/CliBuilder.ts
@@ -43,6 +43,12 @@ export class CliBuilder {
           'What level of logs to report. Any logs of a higher level than the setting are shown.'
       })
       .option('cluster', {
+        deprecated: 'Use --hostname instead',
+        requiresArg: true,
+        describe:
+          'Bright application name (domain name). [default: app.brightsec.com]'
+      })
+      .option('hostname', {
         requiresArg: true,
         describe:
           'Bright application name (domain name). [default: app.brightsec.com]'
@@ -61,12 +67,16 @@ export class CliBuilder {
       .option('proxy-external', {
         requiresArg: true,
         describe:
-          "Specify a proxy URL to route all outbound traffic through. For more information, see the '--proxy' option."
+          'Specify a proxy URL to route all outbound traffic through. For more information, see the --proxy option.'
       })
       .option('proxy-internal', {
         requiresArg: true,
         describe:
-          "Specify a proxy URL to route all inbound traffic through. For more information, see the '--proxy' option."
+          'Specify a proxy URL to route all inbound traffic through. For more information, see the --proxy option.'
+      })
+      .conflicts({
+        proxy: ['proxy-internal', 'proxy-external'],
+        hostname: 'cluster'
       })
       .middleware((args: Arguments) => {
         ({

--- a/src/RequestExecutor/CertificatesLoader.ts
+++ b/src/RequestExecutor/CertificatesLoader.ts
@@ -52,7 +52,7 @@ export class CertificatesLoader implements Certificates {
     }
 
     logger.warn(
-      `Error Loading Certificate: Cannot load certificates from the system root. Please use "--cacert" option to specify the accurate path to the file. https://docs.brightsec.com/docs/initializing-the-repeater#options`
+      `Error Loading Certificate: Cannot load certificates from the system root. Please use --cacert option to specify the accurate path to the file. https://docs.brightsec.com/docs/initializing-the-repeater#options`
     );
   }
 


### PR DESCRIPTION
Deprecated several commands and options for cleanup and simplification:

Commands:
- `archive:generate`: Deprecated in favor of `archive:upload`, which supports HAR, OAS, or Postman collections. NexMock is no longer supported.

Options:
Common:
- `--cluster`: Deprecated. Use `--hostname` instead.

For the `repeater` command:
- `--rabbitmq`: Deprecated with no direct replacement.
- `--headers`: Deprecated. Use `--header` instead.

For the `archive:upload` command:
- `--variables`: Deprecated. Embed variables directly into the file. For current best practices on handling variables, see https://learning.postman.com/docs/sending-requests/variables/variables/#variable-scopes
- `--headers`: Deprecated in the context of `archive:upload`. Use `--header` when running a scan using the `scan:run` command.
