### PR TITLE
feat(entrypoints): add command to list entrypoints

### DIFF
--- a/src/Commands/GetEntryPoints.ts
+++ b/src/Commands/GetEntryPoints.ts
@@ -1,0 +1,69 @@
+import { EntryPoint, EntryPoints, RestProjectsOptions } from '../EntryPoint';
+import { logger } from '../Utils';
+import { Arguments, Argv, CommandModule } from 'yargs';
+import { container } from 'tsyringe';
+
+export class GetEntryPoints implements CommandModule {
+  public readonly command = 'get-entrypoints [options]';
+  public readonly describe = 'get all entrypoints of the project.';
+
+  public builder(argv: Argv): Argv {
+    return argv
+      .option('token', {
+        alias: 't',
+        describe: 'Bright API-key',
+        requiresArg: true,
+        demandOption: true
+      })
+      .option('project', {
+        alias: 'p',
+        describe: 'ID of the project',
+        requiresArg: true,
+        demandOption: true
+      })
+      .option('verbose', {
+        describe: 'Enable verbose mode',
+        boolean: true,
+        default: false
+      })
+      .middleware((args: Arguments) =>
+        container.register<RestProjectsOptions>(RestProjectsOptions, {
+          useValue: {
+            insecure: args.insecure as boolean,
+            baseURL: args.api as string,
+            apiKey: args.token as string,
+            proxyURL: (args.proxyExternal ?? args.proxy) as string
+          }
+        })
+      );
+  }
+
+  public async handler(args: Arguments): Promise<void> {
+    const entryPointsManager: EntryPoints = container.resolve(EntryPoints);
+
+    try {
+      const entryPoints: EntryPoint[] = await entryPointsManager.entrypoints(
+        args.project as string
+      );
+
+      if (args.verbose) {
+        // eslint-disable-next-line no-console
+        console.log(entryPoints);
+      } else {
+        // eslint-disable-next-line no-console
+        console.log(
+          entryPoints.map((entryPoint) => ({
+            id: entryPoint.id,
+            method: entryPoint.method,
+            url: entryPoint.url
+          }))
+        );
+      }
+
+      process.exit(0);
+    } catch (e) {
+      logger.error(`Error during "get-entrypoints": ${e.error || e.message}`);
+      process.exit(1);
+    }
+  }
+}

--- a/src/Commands/GetEntryPoints.ts
+++ b/src/Commands/GetEntryPoints.ts
@@ -4,7 +4,7 @@ import { Arguments, Argv, CommandModule } from 'yargs';
 import { container } from 'tsyringe';
 
 export class GetEntryPoints implements CommandModule {
-  public readonly command = 'get-entrypoints [options]';
+  public readonly command = 'entrypoints:list [options]';
   public readonly describe = 'get all entrypoints of the project.';
 
   public builder(argv: Argv): Argv {
@@ -48,10 +48,11 @@ export class GetEntryPoints implements CommandModule {
 
       if (args.verbose) {
         // eslint-disable-next-line no-console
-        console.log(entryPoints);
+        console.log('%j', entryPoints);
       } else {
         // eslint-disable-next-line no-console
         console.log(
+          '%j',
           entryPoints.map((entryPoint) => ({
             id: entryPoint.id,
             method: entryPoint.method,
@@ -60,10 +61,10 @@ export class GetEntryPoints implements CommandModule {
         );
       }
 
-      process.exit(0);
+      process.exitCode = 0;
     } catch (e) {
-      logger.error(`Error during "get-entrypoints": ${e.error || e.message}`);
-      process.exit(1);
+      logger.error(`Error during "entrypoints:list": ${e.error || e.message}`);
+      process.exitCode = 1;
     }
   }
 }

--- a/src/Commands/index.ts
+++ b/src/Commands/index.ts
@@ -6,3 +6,4 @@ export { StopScan } from './StopScan';
 export { PollingScanStatus } from './PollingScanStatus';
 export { RunRepeater } from './RunRepeater';
 export { Configure } from './Configure';
+export { GetEntryPoints } from './GetEntryPoints';

--- a/src/Config/container.ts
+++ b/src/Config/container.ts
@@ -34,6 +34,7 @@ import {
   RestScans,
   Scans
 } from '../Scan';
+import { EntryPoints, RestEntryPoints } from '../EntryPoint';
 import {
   Archives,
   DefaultParserFactory,
@@ -166,6 +167,11 @@ container
     { lifecycle: Lifecycle.Singleton }
   )
   .register(Scans, { useClass: RestScans }, { lifecycle: Lifecycle.Singleton })
+  .register(
+    EntryPoints,
+    { useClass: RestEntryPoints },
+    { lifecycle: Lifecycle.Singleton }
+  )
   .register(
     Archives,
     { useClass: RestArchives },

--- a/src/EntryPoint/EntryPoints.ts
+++ b/src/EntryPoint/EntryPoints.ts
@@ -1,0 +1,22 @@
+export interface EntryPoints {
+  entrypoints(projectId: string): Promise<EntryPoint[]>;
+}
+
+export const EntryPoints: unique symbol = Symbol('EntryPoints');
+
+export interface EntryPoint {
+  id: string;
+  method: string;
+  url: string;
+  responseStatus: number;
+  connectivity: string;
+  lastUpdated: string;
+  lastEdited: string;
+  lastValidated: string;
+  parametersCount: number;
+  responseTime: number;
+  status: string;
+  openIssuesCount: number;
+  closedIssuesCount: number;
+  createdAt: string;
+}

--- a/src/EntryPoint/RestEntryPoints.ts
+++ b/src/EntryPoint/RestEntryPoints.ts
@@ -1,0 +1,60 @@
+import { EntryPoints, EntryPoint } from './EntryPoints';
+import { ProxyFactory } from '../Utils';
+import axios, { Axios } from 'axios';
+import { inject, injectable } from 'tsyringe';
+import http from 'node:http';
+import https from 'node:https';
+
+export interface RestProjectsOptions {
+  baseURL: string;
+  apiKey: string;
+  timeout?: number;
+  insecure?: boolean;
+  proxyURL?: string;
+}
+
+export const RestProjectsOptions: unique symbol = Symbol('RestProjectsOptions');
+
+@injectable()
+export class RestEntryPoints implements EntryPoints {
+  private readonly client: Axios;
+
+  constructor(
+    @inject(ProxyFactory) private readonly proxyFactory: ProxyFactory,
+    @inject(RestProjectsOptions)
+    {
+      baseURL,
+      apiKey,
+      insecure,
+      proxyURL,
+      timeout = 10000
+    }: RestProjectsOptions
+  ) {
+    const {
+      httpAgent = new http.Agent(),
+      httpsAgent = new https.Agent({ rejectUnauthorized: !insecure })
+    } = proxyURL
+      ? this.proxyFactory.createProxy({
+          proxyUrl: proxyURL,
+          rejectUnauthorized: !insecure
+        })
+      : {};
+
+    this.client = axios.create({
+      baseURL,
+      timeout,
+      httpAgent,
+      httpsAgent,
+      responseType: 'json',
+      headers: { authorization: `Api-Key ${apiKey}` }
+    });
+  }
+
+  public async entrypoints(projectId: string): Promise<EntryPoint[]> {
+    const res = await this.client.get(
+      `/api/v2/projects/${projectId}/entry-points`
+    );
+
+    return res.data.items;
+  }
+}

--- a/src/EntryPoint/index.ts
+++ b/src/EntryPoint/index.ts
@@ -1,0 +1,2 @@
+export * from './EntryPoints';
+export * from './RestEntryPoints';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ import {
   StopScan,
   UploadArchive,
   VersionCommand,
-  Configure
+  Configure,
+  GetEntryPoints
 } from './Commands';
 import { CliBuilder, container } from './Config';
 
@@ -24,6 +25,7 @@ container.resolve(CliBuilder).build({
     new RetestScan(),
     new StopScan(),
     new UploadArchive(),
-    new Configure()
+    new Configure(),
+    new GetEntryPoints()
   ]
 }).argv;


### PR DESCRIPTION
Add `entrypoints:list` command to get all entrypoints of project:
```bash
bright-cli entrypoints:list --project <project-id>
```

**Output**:
A list of all entry points for the specified project.

**Benefits**:
- Streamlines the process of retrieving project entry points directly from the CLI.
- Enhances integration with CI/CD pipelines.
- Aligns bright-cli capabilities with our existing API features.

**Example**:

```bash
$ bright-cli entrypoints:list --token <api-key> --project <project-id>
[ { "id": "s7vJhe2nmwJZXr1dpxbUmg", "url": "https://brightsec.com" } ]

```