### PR TITLE
fix(*): resolve circular dependency in DI

### DIFF
--- a/src/Commands/Configure.ts
+++ b/src/Commands/Configure.ts
@@ -1,6 +1,6 @@
 import { logger } from '../Utils';
 import { ConnectivityUrls, Platform, TestType, Options } from '../Wizard';
-import { container } from '../Config';
+import container from '../container';
 import { Arguments, Argv, CommandModule } from 'yargs';
 
 export class Configure implements CommandModule {

--- a/src/Commands/RunRepeater.ts
+++ b/src/Commands/RunRepeater.ts
@@ -1,6 +1,6 @@
 import { Cert, RequestExecutorOptions } from '../RequestExecutor';
 import { Helpers, logger } from '../Utils';
-import { container } from '../Config';
+import container from '../container';
 import { DefaultRepeaterServerOptions, RepeaterLauncher } from '../Repeater';
 import { Arguments, Argv, CommandModule } from 'yargs';
 import { captureException } from '@sentry/node';

--- a/src/Commands/UploadArchive.ts
+++ b/src/Commands/UploadArchive.ts
@@ -6,7 +6,7 @@ import {
   SpecType
 } from '../Archive';
 import { Helpers, logger } from '../Utils';
-import { container } from '../Config';
+import container from '../container';
 import { Arguments, Argv, CommandModule } from 'yargs';
 
 export class UploadArchive implements CommandModule {

--- a/src/Config/index.ts
+++ b/src/Config/index.ts
@@ -1,4 +1,3 @@
-export { default as container } from './container';
 export * from './CliBuilder';
 export * from './ConfigReader';
 export * from './CliInfo';

--- a/src/Scan/RestScans.spec.ts
+++ b/src/Scan/RestScans.spec.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { CliInfo } from '../Config';
 import {
   Discovery,

--- a/src/container.ts
+++ b/src/container.ts
@@ -5,14 +5,14 @@ import {
   HttpRequestExecutor,
   RequestExecutor,
   WsRequestExecutor
-} from '../RequestExecutor';
+} from './RequestExecutor';
 import {
   DefaultVirtualScripts,
   FSScriptLoader,
   ScriptLoader,
   VirtualScripts
-} from '../Scripts';
-import { DefaultStartupManager, StartupManager } from '../StartupScripts';
+} from './Scripts';
+import { DefaultStartupManager, StartupManager } from './StartupScripts';
 import {
   AuthConnectivity,
   Connectivity,
@@ -25,7 +25,7 @@ import {
   TCPConnectivity,
   TracerouteConnectivity,
   Tokens
-} from '../Wizard';
+} from './Wizard';
 import {
   BreakpointFactory,
   DefaultBreakpointFactory,
@@ -33,18 +33,18 @@ import {
   PollingFactory,
   RestScans,
   Scans
-} from '../Scan';
-import { EntryPoints, RestEntryPoints } from '../EntryPoint';
+} from './Scan';
+import { EntryPoints, RestEntryPoints } from './EntryPoint';
 import {
   Archives,
   DefaultParserFactory,
   ParserFactory,
   RestArchives
-} from '../Archive';
-import { ConfigReader } from './ConfigReader';
-import { DefaultConfigReader } from './DefaultConfigReader';
-import { CliInfo } from './CliInfo';
-import { CliBuilder } from './CliBuilder';
+} from './Archive';
+import { ConfigReader } from './Config/ConfigReader';
+import { DefaultConfigReader } from './Config/DefaultConfigReader';
+import { CliInfo } from './Config/CliInfo';
+import { CliBuilder } from './Config/CliBuilder';
 import {
   RepeaterServer,
   DefaultRepeaterServer,
@@ -54,8 +54,8 @@ import {
   DefaultRuntimeDetector,
   RepeaterLauncher,
   ServerRepeaterLauncher
-} from '../Repeater';
-import { ProxyFactory, DefaultProxyFactory } from '../Utils';
+} from './Repeater';
+import { ProxyFactory, DefaultProxyFactory } from './Utils';
 import { container, Lifecycle } from 'tsyringe';
 
 container

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,8 @@ import {
   Configure,
   GetEntryPoints
 } from './Commands';
-import { CliBuilder, container } from './Config';
+import { CliBuilder } from './Config';
+import container from './container';
 
 container.resolve(CliBuilder).build({
   commands: [


### PR DESCRIPTION
having this file in config folder causing errors:

```
bright-cli % node -r ts-node/register/transpile-only -r tsconfig-paths/register src/index.ts scan:run --token abc --name abc
[2024-07-01T16:45:24.503Z] [ERROR  ] - Error during "scan:run": TypeInfo not known for "undefined"
```