### PR TITLE
fix: allow node 16 in actions to build linux binary

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
 env:
   VERSION: ${{ github.event.release.tag_name }}
   TARGET_REF: ${{ github.event.release.target_commitish }}
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   install-deps:


### PR DESCRIPTION
Bypasses unsupported node versions check
Node 16 is required to build linux binaries compatible with old distros (see #449)

relates-to: actions/checkout#1809