### PR TITLE
fix(repeater): add cap_net_raw+ep capabilities for node in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,12 @@ RUN set -eux; \
     chmod -R g+rwX /home/node; \
     chown -R 1000 /home/node
 
-RUN apk add --no-cache libcap && setcap 'cap_net_raw+ep' $(which node)
+RUN set -eux; \
+    apk upgrade --no-cache; \
+    apk add --no-cache libcap; \
+    rm -rf /var/cache/apk/*
+    
+RUN setcap 'cap_net_raw+ep' $(which node)
 
 # change workgin dir
 WORKDIR $HOME/

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,8 @@ RUN set -eux; \
     chmod -R g+rwX /home/node; \
     chown -R 1000 /home/node
 
+RUN apk add --no-cache libcap && setcap 'cap_net_raw+ep' $(which node)
+
 # change workgin dir
 WORKDIR $HOME/
 


### PR DESCRIPTION
running traceroute requires root access as it creates raw sockets.
Since we use non-root user in Docker image, we need to allow the
node to create raw sockets and listen of ICMP error packets.

for that use the setcap command which comes in libcap package:
    setcap 'cap_net_raw+ep' $(which node)