### PR TITLE
fix: replace broken CentOS package mirrors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,9 +99,11 @@ jobs:
       - name: Install dev-deps
         if: startsWith(matrix.os, 'ubuntu')
         run: |
-          yum install build-essential python3 -y \
-            && yum clean all -y \
-            && rm -rf /var/cache/yum
+          sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+          && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+          && yum install build-essential python3 -y \
+          && yum clean all -y \
+          && rm -rf /var/cache/yum
 
       - name: Install deps
         uses: ./.github/workflows/composite/npm


### PR DESCRIPTION
CentOS 7 reached EOL on June 30, 2024 which also marked EOL for mirrorlist.centos.org