### PR TITLE
fix: use macOS 12 to build binary

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
           - os: windows-2019
             target: win
             node: 20
-          - os: macos-11
+          - os: macos-14-large
             target: macos
             node: 20
           # Using the `centos7-devtoolset7` runner instead of latest (i.e. `ubuntu-20.04`)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
           - os: windows-2019
             target: win
             node: 20
-          - os: macos-14-large
+          - os: macos-12
             target: macos
             node: 20
           # Using the `centos7-devtoolset7` runner instead of latest (i.e. `ubuntu-20.04`)


### PR DESCRIPTION
Fixes builds as macOS 11 runners are removed