### PR TITLE
fix(scan): correct param handling to respect user provided values

### DIFF
--- a/src/Scan/RestScans.ts
+++ b/src/Scan/RestScans.ts
@@ -150,9 +150,9 @@ export class RestScans implements Scans {
     scanConfig: Omit<ScanConfig, 'headers'>
   ): Promise<Omit<ScanConfig, 'headers'>> {
     const attackParamLocations =
-      scanConfig.attackParamLocations ?? scanConfig.templateId
-        ? undefined
-        : [...ATTACK_PARAM_LOCATIONS_DEFAULT];
+      scanConfig.attackParamLocations ??
+      (scanConfig.templateId ? undefined : [...ATTACK_PARAM_LOCATIONS_DEFAULT]);
+
     const exclusions =
       scanConfig.exclusions?.params || scanConfig.exclusions?.requests
         ? scanConfig.exclusions


### PR DESCRIPTION
the `applyDefaultSettings` was doing null check a little wrong and as a result the default param were always applied. 