### PR TITLE
feat(scan): run scan with project level entrypoints

### DIFF
--- a/src/Commands/RunScan.ts
+++ b/src/Commands/RunScan.ts
@@ -153,6 +153,14 @@ export class RunScan implements CommandModule {
         choices: Helpers.toArray(AttackParamLocation),
         describe: 'Defines which part of the request to attack.'
       })
+      .option('entrypoint', {
+        array: true,
+        alias: 'e',
+        describe:
+          'A list of entry points to start the scan from' +
+          'The maximum number of entry points allowed is 2000' +
+          'Pass an empty list to use the first 2000 entry points of project'
+      })
       .group(['archive', 'crawler'], 'Discovery Options')
       .group(
         ['host-filter', 'header', 'module', 'repeater', 'test', 'smart'],
@@ -192,7 +200,8 @@ export class RunScan implements CommandModule {
         exclusions: {
           requests: args.excludeEntryPoint,
           params: args.excludeParam
-        }
+        },
+        entryPointIds: args.entrypoint
       } as ScanConfig);
 
       // eslint-disable-next-line no-console

--- a/src/Scan/Scans.ts
+++ b/src/Scan/Scans.ts
@@ -62,6 +62,7 @@ export interface ScanConfig {
   crawlerUrls?: string[];
   hostsFilter?: string[];
   repeaters?: string[];
+  entryPointIds?: string[];
 }
 
 export enum ScanStatus {


### PR DESCRIPTION
Users can pass a list of entrypoint IDs to run the scan on specific entrypoints.
For Example:
```
bright-cli scan:run --entrypoint <entrypoint_id1> <entrypoint_id2> <entrypoint_id3> ...
```

If a project is specified and the `--entrypoint` flag is added without specifying entrypoint IDs, the scan will run on the first 2000 project-level entrypoints.
For example:
```
bright-cli scan:run --project <PROJECT_ID> --entrypoint
```

 