### PR TITLE
fix(repeater): introduce max-body-size to avoid breaking socket connection on large responses

### DIFF
--- a/src/Commands/RunRepeater.ts
+++ b/src/Commands/RunRepeater.ts
@@ -167,7 +167,7 @@ export class RunRepeater implements CommandModule {
               timeout: args.timeout as number,
               proxyUrl: (args.proxyInternal ?? args.proxy) as string,
               certs: args.cert as Cert[],
-              maxBodySize: 100 * 1024,
+              maxBodySize: Infinity,
               maxContentLength: 100,
               reuseConnection:
                 !!args.ntlm || !!args.experimentalConnectionReuse,

--- a/src/Commands/RunRepeater.ts
+++ b/src/Commands/RunRepeater.ts
@@ -167,24 +167,28 @@ export class RunRepeater implements CommandModule {
               timeout: args.timeout as number,
               proxyUrl: (args.proxyInternal ?? args.proxy) as string,
               certs: args.cert as Cert[],
+              maxBodySize: 100 * 1024,
               maxContentLength: 100,
               reuseConnection:
                 !!args.ntlm || !!args.experimentalConnectionReuse,
               whitelistMimes: [
-                'text/html',
-                'text/plain',
-                'text/css',
-                'text/javascript',
-                'text/markdown',
-                'text/xml',
-                'application/javascript',
-                'application/x-javascript',
-                'application/json',
-                'application/xml',
-                'application/x-www-form-urlencoded',
-                'application/msgpack',
-                'application/ld+json',
-                'application/graphql'
+                { type: 'text/html', allowTruncation: false },
+                { type: 'text/plain', allowTruncation: true },
+                { type: 'text/css', allowTruncation: false },
+                { type: 'text/javascript', allowTruncation: false },
+                { type: 'text/markdown', allowTruncation: true },
+                { type: 'text/xml', allowTruncation: false },
+                { type: 'application/javascript', allowTruncation: false },
+                { type: 'application/x-javascript', allowTruncation: false },
+                { type: 'application/json', allowTruncation: false },
+                { type: 'application/xml', allowTruncation: false },
+                {
+                  type: 'application/x-www-form-urlencoded',
+                  allowTruncation: false
+                },
+                { type: 'application/msgpack', allowTruncation: false },
+                { type: 'application/ld+json', allowTruncation: false },
+                { type: 'application/graphql', allowTruncation: false }
               ]
             }
           })

--- a/src/Repeater/DefaultRepeaterServer.ts
+++ b/src/Repeater/DefaultRepeaterServer.ts
@@ -17,7 +17,7 @@ import {
   RepeaterServerRequestResponse,
   RepeaterServerScriptsUpdatedEvent,
   RepeaterUpgradeAvailableEvent,
-  RepeaterCommunicateLimitsEvent
+  RepeaterLimitsEvent
 } from './RepeaterServer';
 import { inject, injectable } from 'tsyringe';
 import io, { Socket } from 'socket.io-client';
@@ -53,7 +53,7 @@ const enum SocketEvents {
   SCRIPT_UPDATED = 'scripts-updated',
   PING = 'ping',
   REQUEST = 'request',
-  COMMUNICATE_LIMITS = 'communicate-limits'
+  LIMITS = 'limits'
 }
 
 interface SocketListeningEventMap {
@@ -74,9 +74,7 @@ interface SocketListeningEventMap {
     request: RepeaterServerRequestEvent,
     callback: CallbackFunction<RepeaterServerRequestResponse>
   ) => void;
-  [SocketEvents.COMMUNICATE_LIMITS]: (
-    request: RepeaterCommunicateLimitsEvent
-  ) => void;
+  [SocketEvents.LIMITS]: (request: RepeaterLimitsEvent) => void;
 }
 
 interface SocketEmitEventMap {
@@ -230,8 +228,8 @@ export class DefaultRepeaterServer implements RepeaterServer {
     this.socket.on(SocketEvents.SCRIPT_UPDATED, (event) =>
       this.events.emit(RepeaterServerEvents.SCRIPTS_UPDATED, event)
     );
-    this.socket.on(SocketEvents.COMMUNICATE_LIMITS, (event) =>
-      this.events.emit(RepeaterServerEvents.COMMUNICATE_LIMITS, event)
+    this.socket.on(SocketEvents.LIMITS, (event) =>
+      this.events.emit(RepeaterServerEvents.LIMITS, event)
     );
   }
 

--- a/src/Repeater/DefaultRepeaterServer.ts
+++ b/src/Repeater/DefaultRepeaterServer.ts
@@ -16,7 +16,8 @@ import {
   RepeaterServerRequestEvent,
   RepeaterServerRequestResponse,
   RepeaterServerScriptsUpdatedEvent,
-  RepeaterUpgradeAvailableEvent
+  RepeaterUpgradeAvailableEvent,
+  RepeaterCommunicateLimitsEvent
 } from './RepeaterServer';
 import { inject, injectable } from 'tsyringe';
 import io, { Socket } from 'socket.io-client';
@@ -51,7 +52,8 @@ const enum SocketEvents {
   UPDATE_AVAILABLE = 'update-available',
   SCRIPT_UPDATED = 'scripts-updated',
   PING = 'ping',
-  REQUEST = 'request'
+  REQUEST = 'request',
+  COMMUNICATE_LIMITS = 'communicate-limits'
 }
 
 interface SocketListeningEventMap {
@@ -71,6 +73,9 @@ interface SocketListeningEventMap {
   [SocketEvents.REQUEST]: (
     request: RepeaterServerRequestEvent,
     callback: CallbackFunction<RepeaterServerRequestResponse>
+  ) => void;
+  [SocketEvents.COMMUNICATE_LIMITS]: (
+    request: RepeaterCommunicateLimitsEvent
   ) => void;
 }
 
@@ -224,6 +229,9 @@ export class DefaultRepeaterServer implements RepeaterServer {
     );
     this.socket.on(SocketEvents.SCRIPT_UPDATED, (event) =>
       this.events.emit(RepeaterServerEvents.SCRIPTS_UPDATED, event)
+    );
+    this.socket.on(SocketEvents.COMMUNICATE_LIMITS, (event) =>
+      this.events.emit(RepeaterServerEvents.COMMUNICATE_LIMITS, event)
     );
   }
 

--- a/src/Repeater/RepeaterServer.ts
+++ b/src/Repeater/RepeaterServer.ts
@@ -80,6 +80,10 @@ export interface RepeaterUpgradeAvailableEvent {
   version: string;
 }
 
+export interface RepeaterCommunicateLimitsEvent {
+  maxBodySize: number;
+}
+
 export interface RepeaterServerScriptsUpdatedEvent {
   script: string | Record<string, string>;
 }
@@ -107,6 +111,7 @@ export const enum RepeaterServerEvents {
   REQUEST = 'request',
   TEST_NETWORK = 'test_network',
   UPDATE_AVAILABLE = 'update_available',
+  COMMUNICATE_LIMITS = 'communicate-limits',
   SCRIPTS_UPDATED = 'scripts_updated',
   RECONNECTION_FAILED = 'reconnection_failed',
   RECONNECT_ATTEMPT = 'reconnect_attempt',

--- a/src/Repeater/RepeaterServer.ts
+++ b/src/Repeater/RepeaterServer.ts
@@ -80,7 +80,7 @@ export interface RepeaterUpgradeAvailableEvent {
   version: string;
 }
 
-export interface RepeaterCommunicateLimitsEvent {
+export interface RepeaterLimitsEvent {
   maxBodySize: number;
 }
 
@@ -111,7 +111,7 @@ export const enum RepeaterServerEvents {
   REQUEST = 'request',
   TEST_NETWORK = 'test_network',
   UPDATE_AVAILABLE = 'update_available',
-  COMMUNICATE_LIMITS = 'communicate-limits',
+  LIMITS = 'limits',
   SCRIPTS_UPDATED = 'scripts_updated',
   RECONNECTION_FAILED = 'reconnection_failed',
   RECONNECT_ATTEMPT = 'reconnect_attempt',
@@ -128,7 +128,7 @@ export interface RepeaterServerEventsMap {
   [RepeaterServerEvents.REQUEST]: RepeaterServerRequestEvent;
   [RepeaterServerEvents.TEST_NETWORK]: RepeaterServerNetworkTestEvent;
   [RepeaterServerEvents.UPDATE_AVAILABLE]: RepeaterUpgradeAvailableEvent;
-  [RepeaterServerEvents.COMMUNICATE_LIMITS]: RepeaterCommunicateLimitsEvent;
+  [RepeaterServerEvents.LIMITS]: RepeaterLimitsEvent;
   [RepeaterServerEvents.SCRIPTS_UPDATED]: RepeaterServerScriptsUpdatedEvent;
   [RepeaterServerEvents.RECONNECTION_FAILED]: RepeaterServerReconnectionFailedEvent;
   [RepeaterServerEvents.RECONNECT_ATTEMPT]: RepeaterServerReconnectionAttemptedEvent;

--- a/src/Repeater/RepeaterServer.ts
+++ b/src/Repeater/RepeaterServer.ts
@@ -128,6 +128,7 @@ export interface RepeaterServerEventsMap {
   [RepeaterServerEvents.REQUEST]: RepeaterServerRequestEvent;
   [RepeaterServerEvents.TEST_NETWORK]: RepeaterServerNetworkTestEvent;
   [RepeaterServerEvents.UPDATE_AVAILABLE]: RepeaterUpgradeAvailableEvent;
+  [RepeaterServerEvents.COMMUNICATE_LIMITS]: RepeaterCommunicateLimitsEvent;
   [RepeaterServerEvents.SCRIPTS_UPDATED]: RepeaterServerScriptsUpdatedEvent;
   [RepeaterServerEvents.RECONNECTION_FAILED]: RepeaterServerReconnectionFailedEvent;
   [RepeaterServerEvents.RECONNECT_ATTEMPT]: RepeaterServerReconnectionAttemptedEvent;

--- a/src/Repeater/ServerRepeaterLauncher.ts
+++ b/src/Repeater/ServerRepeaterLauncher.ts
@@ -1,7 +1,7 @@
 import { RepeaterLauncher } from './RepeaterLauncher';
 import {
   DeploymentRuntime,
-  RepeaterCommunicateLimitsEvent,
+  RepeaterLimitsEvent,
   RepeaterErrorCodes,
   RepeaterServer,
   RepeaterServerErrorEvent,
@@ -137,10 +137,7 @@ export class ServerRepeaterLauncher implements RepeaterLauncher {
       this.reconnectionFailed
     );
     this.repeaterServer.on(RepeaterServerEvents.REQUEST, this.requestReceived);
-    this.repeaterServer.on(
-      RepeaterServerEvents.COMMUNICATE_LIMITS,
-      this.limitsReceived
-    );
+    this.repeaterServer.on(RepeaterServerEvents.LIMITS, this.limitsReceived);
     this.repeaterServer.on(
       RepeaterServerEvents.TEST_NETWORK,
       this.testingNetwork
@@ -241,7 +238,7 @@ export class ServerRepeaterLauncher implements RepeaterLauncher {
     }
   };
 
-  private limitsReceived = (event: RepeaterCommunicateLimitsEvent) => {
+  private limitsReceived = (event: RepeaterLimitsEvent) => {
     logger.debug('Limits received: %i', event.maxBodySize);
     this.requestExecutorOptions.maxBodySize = event.maxBodySize;
   };

--- a/src/RequestExecutor/RequestExecutorOptions.ts
+++ b/src/RequestExecutor/RequestExecutorOptions.ts
@@ -1,11 +1,17 @@
 import { Cert } from './Request';
 
+export interface WhitelistMimeType {
+  type: string;
+  allowTruncation?: boolean;
+}
+
 export interface RequestExecutorOptions {
   timeout?: number;
   proxyUrl?: string;
   headers?: Record<string, string | string[]>;
   certs?: Cert[];
-  whitelistMimes?: string[];
+  whitelistMimes?: WhitelistMimeType[];
+  maxBodySize?: number;
   maxContentLength?: number;
   reuseConnection?: boolean;
 }


### PR DESCRIPTION
Introduce a maxBodySize limit to manage large response bodies, truncating or omitting them as necessary to prevent socket connection disruptions