### PR TITLE
fix(cli): revert nodejs capability settings from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,6 @@ RUN set -eux; \
     apk add --no-cache libcap; \
     rm -rf /var/cache/apk/*
     
-RUN setcap 'cap_net_raw+ep' $(which node)
-
 # change workgin dir
 WORKDIR $HOME/
 


### PR DESCRIPTION
earlier the "setcap 'cap_net_raw+ep' $(which node)" option has been added to Dockerfile in order to make traceroute feature to work. But changing the capability setting causing "operation not permitted" error on client who run cli in secure environments like Openshift.

We revert this setting for now to unblock users, and fix the traceroute later.