### PR TITLE
ci: fix node20 compatibility issues in e2e pipeline

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,6 +41,9 @@ jobs:
     if: ${{ inputs.test-executables }}
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     strategy:
       fail-fast: false
       matrix:
@@ -94,7 +97,7 @@ jobs:
             && rm -rf /var/lib/apt/lists/*
 
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Download Executable
         shell: bash
@@ -125,6 +128,7 @@ jobs:
           E2E_REPEATER_TARGET_URL: ${{ format('http://localhost:{0}', steps.target.outputs.port) }}
           E2E_REPEATER_TARGET_CMD: ${{ steps.target.outputs.cmd }}
           E2E_TEST_TIMEOUT: ${{ inputs.test_timeout }}
+
   msi:
     if: ${{ inputs.test-msi }}
     runs-on: windows-latest
@@ -175,6 +179,7 @@ jobs:
           E2E_REPEATER_TARGET_URL: ${{ format('http://localhost:{0}', steps.target.outputs.port) }}
           E2E_REPEATER_TARGET_CMD: ${{ steps.target.outputs.cmd }}
           E2E_TEST_TIMEOUT: ${{ inputs.test_timeout }}
+
   docker:
     if: ${{ inputs.test-docker }}
     runs-on: ${{ matrix.os }}
@@ -193,7 +198,7 @@ jobs:
         run: docker pull brightsec/cli:${{ inputs.version }}
 
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Download Target
         id: target
@@ -217,10 +222,14 @@ jobs:
           E2E_REPEATER_TARGET_URL: ${{ format('http://host.docker.internal:{0}', steps.target.outputs.port) }}
           E2E_REPEATER_TARGET_CMD: ${{ steps.target.outputs.cmd }}
           E2E_TEST_TIMEOUT: ${{ inputs.test_timeout }}
+
   npm:
     if: ${{ inputs.test-npm }}
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     strategy:
       fail-fast: false
       matrix:
@@ -257,7 +266,7 @@ jobs:
             && rm -rf /var/lib/apt/lists/*
 
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Download Target
         id: target

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -97,7 +97,7 @@ jobs:
             && rm -rf /var/lib/apt/lists/*
 
       - name: Checkout Repository
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@2
 
       - name: Download Executable
         shell: bash
@@ -198,7 +198,7 @@ jobs:
         run: docker pull brightsec/cli:${{ inputs.version }}
 
       - name: Checkout Repository
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@2
 
       - name: Download Target
         id: target
@@ -266,7 +266,7 @@ jobs:
             && rm -rf /var/lib/apt/lists/*
 
       - name: Checkout Repository
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@2
 
       - name: Download Target
         id: target

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -97,7 +97,7 @@ jobs:
             && rm -rf /var/lib/apt/lists/*
 
       - name: Checkout Repository
-        uses: actions/checkout@2
+        uses: actions/checkout@v2
 
       - name: Download Executable
         shell: bash
@@ -198,7 +198,7 @@ jobs:
         run: docker pull brightsec/cli:${{ inputs.version }}
 
       - name: Checkout Repository
-        uses: actions/checkout@2
+        uses: actions/checkout@v2
 
       - name: Download Target
         id: target
@@ -266,7 +266,7 @@ jobs:
             && rm -rf /var/lib/apt/lists/*
 
       - name: Checkout Repository
-        uses: actions/checkout@2
+        uses: actions/checkout@v2
 
       - name: Download Target
         id: target


### PR DESCRIPTION
e2e pipeline fails on Ubuntu 16.04 and 18.04 due to the recent default switch to node20 in actions/checkout. Node20 requires GLIBC 2.28 or higher, which these environments lack. To resolve this, we’re setting the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` environment variable to allow fallback to a compatible Node version, restoring pipeline stability.

Useful links:
* [GitHub changelog: node20 default](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)
* [GitHub issue #1809](https://github.com/actions/checkout/issues/1809)