### PR TITLE
ci: use macos-12 for e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,7 +67,7 @@ jobs:
           - os: ubuntu-latest
             executable: bright-cli-linux-x64
             node: 20
-          - os: macos-11
+          - os: macos-12
             executable: bright-cli-macos-x64
             node: 20
           - os: macos-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -187,14 +187,12 @@ jobs:
       fail-fast: false
       matrix:
         # Windows can't run linux docker images: https://github.com/actions/runner-images/issues/1143
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     steps:
       - name: Install Docker (MacOS)
         if: ${{ startsWith(matrix.os, 'macos') }}
+        uses: docker-practice/actions-setup-docker@master
         timeout-minutes: 12
-        run: |
-          brew install docker colima
-          colima start
 
       - name: Pull Image
         run: docker pull brightsec/cli:${{ inputs.version }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -187,12 +187,14 @@ jobs:
       fail-fast: false
       matrix:
         # Windows can't run linux docker images: https://github.com/actions/runner-images/issues/1143
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Install Docker (MacOS)
         if: ${{ startsWith(matrix.os, 'macos') }}
-        uses: docker-practice/actions-setup-docker@master
         timeout-minutes: 12
+        run: |
+          brew install docker
+          colima start
 
       - name: Pull Image
         run: docker pull brightsec/cli:${{ inputs.version }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -187,7 +187,7 @@ jobs:
       fail-fast: false
       matrix:
         # Windows can't run linux docker images: https://github.com/actions/runner-images/issues/1143
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     steps:
       - name: Install Docker (MacOS)
         if: ${{ startsWith(matrix.os, 'macos') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,7 @@ on:
           - development
       test_timeout:
         description: "Test timeout in seconds"
-        default: 3600
+        default: 5000
 
 jobs:
   executables:
@@ -187,7 +187,7 @@ jobs:
       fail-fast: false
       matrix:
         # Windows can't run linux docker images: https://github.com/actions/runner-images/issues/1143
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Install Docker (MacOS)
         if: ${{ startsWith(matrix.os, 'macos') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -193,7 +193,7 @@ jobs:
         if: ${{ startsWith(matrix.os, 'macos') }}
         timeout-minutes: 12
         run: |
-          brew install docker
+          brew install docker colima
           colima start
 
       - name: Pull Image

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Install Docker (MacOS)
         if: ${{ startsWith(matrix.os, 'macos') }}
         uses: docker-practice/actions-setup-docker@master
-        timeout-minutes: 12
+        timeout-minutes: 30
 
       - name: Pull Image
         run: docker pull brightsec/cli:${{ inputs.version }}


### PR DESCRIPTION
`macos-11` runner has been [deprecated and removed](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/) from the list of available hosted runners in GitHub