### PR TITLE
build(deps): bump os-service from 1.2.2 to 1.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "12.7.0-next.2",
       "license": "MIT",
       "dependencies": {
-        "@neuralegion/os-service": "1.2.2",
+        "@neuralegion/os-service": "^1.2.6",
         "@neuralegion/raw-socket": "1.8.2",
         "@sentry/node": "^7.70.0",
         "ajv": "^6.12.6",
@@ -2093,20 +2093,16 @@
       }
     },
     "node_modules/@neuralegion/os-service": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@neuralegion/os-service/-/os-service-1.2.2.tgz",
-      "integrity": "sha512-JfdTBiAqSxx+FY3pSSjOY0NvXkAqEXS1/ZuW/M8NchgdIbqEMruxlPF3Y0HsRInRwkNQLAkcomRIK9uhiEhHqw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@neuralegion/os-service/-/os-service-1.2.6.tgz",
+      "integrity": "sha512-NxaRChHY4w32XKqZqnjLaLk3VPTtymHBLJl2gGok5Jy9Dj9LcSWsW3c3XIYycWzriOZBfwxrJbJpR/i8+Pb4uQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "nan": "~2.17.0",
-        "node-gyp-build": "^4.6.1",
+        "nan": "^2.22.0",
+        "node-gyp-build": "^4.8.3",
         "plist": "^3.1.0"
       }
-    },
-    "node_modules/@neuralegion/os-service/node_modules/nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "node_modules/@neuralegion/raw-socket": {
       "version": "1.8.2",
@@ -9477,6 +9473,12 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/nan": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "license": "MIT"
+    },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -9572,9 +9574,10 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
-      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.3.tgz",
+      "integrity": "sha512-EMS95CMJzdoSKoIiXo8pxKoL8DYxwIZXYlLmgPb8KUv794abpnLK6ynsCAWNliOjREKruYKdzbh76HHYUHX7nw==",
+      "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -17273,20 +17276,13 @@
       }
     },
     "@neuralegion/os-service": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@neuralegion/os-service/-/os-service-1.2.2.tgz",
-      "integrity": "sha512-JfdTBiAqSxx+FY3pSSjOY0NvXkAqEXS1/ZuW/M8NchgdIbqEMruxlPF3Y0HsRInRwkNQLAkcomRIK9uhiEhHqw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@neuralegion/os-service/-/os-service-1.2.6.tgz",
+      "integrity": "sha512-NxaRChHY4w32XKqZqnjLaLk3VPTtymHBLJl2gGok5Jy9Dj9LcSWsW3c3XIYycWzriOZBfwxrJbJpR/i8+Pb4uQ==",
       "requires": {
-        "nan": "~2.17.0",
-        "node-gyp-build": "^4.6.1",
+        "nan": "^2.22.0",
+        "node-gyp-build": "^4.8.3",
         "plist": "^3.1.0"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.17.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-          "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
-        }
       }
     },
     "@neuralegion/raw-socket": {
@@ -22765,6 +22761,11 @@
         }
       }
     },
+    "nan": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw=="
+    },
     "napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -22837,9 +22838,9 @@
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "node-gyp-build": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
-      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ=="
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.3.tgz",
+      "integrity": "sha512-EMS95CMJzdoSKoIiXo8pxKoL8DYxwIZXYlLmgPb8KUv794abpnLK6ynsCAWNliOjREKruYKdzbh76HHYUHX7nw=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=16 <=20"
   },
   "dependencies": {
-    "@neuralegion/os-service": "1.2.2",
+    "@neuralegion/os-service": "^1.2.6",
     "@neuralegion/raw-socket": "1.8.2",
     "@sentry/node": "^7.70.0",
     "ajv": "^6.12.6",


### PR DESCRIPTION
Together with #609, enables updating Node.js to the latest LTS version (v22) to support the full range of runtimes, as specified in the public docs (the last 3 LTS)