### PR TITLE
build(deps): bump raw-socket from 1.8.2 to 1.8.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "12.7.0-next.2",
       "license": "MIT",
       "dependencies": {
-        "@neuralegion/os-service": "1.2.2",
+        "@neuralegion/os-service": "^1.2.6",
         "@neuralegion/raw-socket": "1.8.2",
         "@sentry/node": "^7.70.0",
         "ajv": "^6.12.6",
@@ -2093,20 +2093,16 @@
       }
     },
     "node_modules/@neuralegion/os-service": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@neuralegion/os-service/-/os-service-1.2.2.tgz",
-      "integrity": "sha512-JfdTBiAqSxx+FY3pSSjOY0NvXkAqEXS1/ZuW/M8NchgdIbqEMruxlPF3Y0HsRInRwkNQLAkcomRIK9uhiEhHqw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@neuralegion/os-service/-/os-service-1.2.6.tgz",
+      "integrity": "sha512-NxaRChHY4w32XKqZqnjLaLk3VPTtymHBLJl2gGok5Jy9Dj9LcSWsW3c3XIYycWzriOZBfwxrJbJpR/i8+Pb4uQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "nan": "~2.17.0",
-        "node-gyp-build": "^4.6.1",
+        "nan": "^2.22.0",
+        "node-gyp-build": "^4.8.3",
         "plist": "^3.1.0"
       }
-    },
-    "node_modules/@neuralegion/os-service/node_modules/nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "node_modules/@neuralegion/raw-socket": {
       "version": "1.8.2",
@@ -9477,6 +9473,12 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/nan": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "license": "MIT"
+    },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -9572,9 +9574,10 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
-      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.3.tgz",
+      "integrity": "sha512-EMS95CMJzdoSKoIiXo8pxKoL8DYxwIZXYlLmgPb8KUv794abpnLK6ynsCAWNliOjREKruYKdzbh76HHYUHX7nw==",
+      "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -17273,20 +17276,13 @@
       }
     },
     "@neuralegion/os-service": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@neuralegion/os-service/-/os-service-1.2.2.tgz",
-      "integrity": "sha512-JfdTBiAqSxx+FY3pSSjOY0NvXkAqEXS1/ZuW/M8NchgdIbqEMruxlPF3Y0HsRInRwkNQLAkcomRIK9uhiEhHqw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@neuralegion/os-service/-/os-service-1.2.6.tgz",
+      "integrity": "sha512-NxaRChHY4w32XKqZqnjLaLk3VPTtymHBLJl2gGok5Jy9Dj9LcSWsW3c3XIYycWzriOZBfwxrJbJpR/i8+Pb4uQ==",
       "requires": {
-        "nan": "~2.17.0",
-        "node-gyp-build": "^4.6.1",
+        "nan": "^2.22.0",
+        "node-gyp-build": "^4.8.3",
         "plist": "^3.1.0"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.17.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-          "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
-        }
       }
     },
     "@neuralegion/raw-socket": {
@@ -22765,6 +22761,11 @@
         }
       }
     },
+    "nan": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw=="
+    },
     "napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -22837,9 +22838,9 @@
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "node-gyp-build": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
-      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ=="
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.3.tgz",
+      "integrity": "sha512-EMS95CMJzdoSKoIiXo8pxKoL8DYxwIZXYlLmgPb8KUv794abpnLK6ynsCAWNliOjREKruYKdzbh76HHYUHX7nw=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@neuralegion/os-service": "^1.2.6",
-        "@neuralegion/raw-socket": "1.8.2",
+        "@neuralegion/raw-socket": "^1.8.6",
         "@sentry/node": "^7.70.0",
         "ajv": "^6.12.6",
         "amqplib": "~0.10.2",
@@ -2105,19 +2105,15 @@
       }
     },
     "node_modules/@neuralegion/raw-socket": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@neuralegion/raw-socket/-/raw-socket-1.8.2.tgz",
-      "integrity": "sha512-+ZeOG3imae1bAN9Z9kkUR4AMl96Up+8/JtCYGzGeFj+RTPN7v/Nd3u6vHGisZ/s/vM8gKD/njiAameW982sVxw==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@neuralegion/raw-socket/-/raw-socket-1.8.6.tgz",
+      "integrity": "sha512-LW0O6cv++9wQUvPJKKgD9Lfy7rerEBf/iLFnLGh4N2PUsJZVvfFcWfXdHnDuSi5T3bXav/kIs7yJHQmtth4Xig==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "nan": "~2.17.0",
-        "node-gyp-build": "^4.6.1"
+        "nan": "^2.22.0",
+        "node-gyp-build": "^4.8.3"
       }
-    },
-    "node_modules/@neuralegion/raw-socket/node_modules/nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8764,19 +8760,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lint-staged/node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/lint-staged/node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -8829,18 +8812,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lint-staged/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/lint-staged/node_modules/strip-final-newline": {
@@ -9327,13 +9298,14 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -12806,10 +12778,11 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -17286,19 +17259,12 @@
       }
     },
     "@neuralegion/raw-socket": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@neuralegion/raw-socket/-/raw-socket-1.8.2.tgz",
-      "integrity": "sha512-+ZeOG3imae1bAN9Z9kkUR4AMl96Up+8/JtCYGzGeFj+RTPN7v/Nd3u6vHGisZ/s/vM8gKD/njiAameW982sVxw==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@neuralegion/raw-socket/-/raw-socket-1.8.6.tgz",
+      "integrity": "sha512-LW0O6cv++9wQUvPJKKgD9Lfy7rerEBf/iLFnLGh4N2PUsJZVvfFcWfXdHnDuSi5T3bXav/kIs7yJHQmtth4Xig==",
       "requires": {
-        "nan": "~2.17.0",
-        "node-gyp-build": "^4.6.1"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.17.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-          "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
-        }
+        "nan": "^2.22.0",
+        "node-gyp-build": "^4.8.3"
       }
     },
     "@nodelib/fs.scandir": {
@@ -22245,16 +22211,6 @@
           "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
           "dev": true
         },
-        "micromatch": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "picomatch": "^2.3.1"
-          }
-        },
         "mimic-fn": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -22283,12 +22239,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
           "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-          "dev": true
-        },
-        "picomatch": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
           "dev": true
         },
         "strip-final-newline": {
@@ -22663,13 +22613,13 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
       }
     },
     "mime": {
@@ -25014,9 +24964,9 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "pidtree": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=16 <=20"
   },
   "dependencies": {
-    "@neuralegion/os-service": "1.2.2",
+    "@neuralegion/os-service": "^1.2.6",
     "@neuralegion/raw-socket": "1.8.2",
     "@sentry/node": "^7.70.0",
     "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@neuralegion/os-service": "^1.2.6",
-    "@neuralegion/raw-socket": "1.8.2",
+    "@neuralegion/raw-socket": "^1.8.6",
     "@sentry/node": "^7.70.0",
     "ajv": "^6.12.6",
     "amqplib": "~0.10.2",


### PR DESCRIPTION
Together with #608, enables updating Node.js to the latest LTS version (v22) to support the full range of runtimes, as specified in the public docs (the last 3 LTS)