### PR TITLE
build(deps-dev): bump actions/download-artifact and actions/upload-artifact from 3 to 4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
           tag: ${{ github.ref }}
           file_glob: true
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build
           path: |
@@ -92,7 +92,7 @@ jobs:
           ref: ${{ env.TARGET_REF }}
           token: ${{ secrets.GPR_TOKEN }}
 
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -145,7 +145,7 @@ jobs:
           ref: ${{ env.TARGET_REF }}
           token: ${{ secrets.GPR_TOKEN }}
 
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v4
         with:
           name: build
 


### PR DESCRIPTION
Ensure the artifact is gonna be uploaded using a compatible version of `actions/upload-artifact` with `actions/download-artifact`. For more information, visit the GitHub Artifacts FAQ: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md