### PR TITLE
feat(*): write to stderr for errors and warnings

### DIFF
--- a/src/Utils/Logger.ts
+++ b/src/Utils/Logger.ts
@@ -80,18 +80,18 @@ export class Logger {
   }
 
   private write(message: string, level: LogLevel, ...args: any[]): void {
-    const message = `${this.formatHeader(level)} - ${message}`;
+    const logMessage = `${this.formatHeader(level)} - ${message}`;
 
     if (level <= LogLevel.WARN) {
       // write to stderr for errors and warnings
       // eslint-disable-next-line no-console
-      console.error(message, ...args);
+      console.error(logMessage, ...args);
 
       return;
     }
 
     // eslint-disable-next-line no-console
-    console.log(message, ...args);
+    console.log(logMessage, ...args);
   }
 
   private formatHeader(level: LogLevel): string {

--- a/src/Utils/Logger.ts
+++ b/src/Utils/Logger.ts
@@ -80,16 +80,18 @@ export class Logger {
   }
 
   private write(message: string, level: LogLevel, ...args: any[]): void {
+    const message = `${this.formatHeader(level)} - ${message}`;
+    
     if (level <= LogLevel.WARN) {
       // write to stderr for errors and warnings
       // eslint-disable-next-line no-console
-      console.error(`${this.formatHeader(level)} - ${message}`, ...args);
+      console.error(message, ...args);
 
       return;
     }
 
     // eslint-disable-next-line no-console
-    console.log(`${this.formatHeader(level)} - ${message}`, ...args);
+    console.log(message, ...args);
   }
 
   private formatHeader(level: LogLevel): string {

--- a/src/Utils/Logger.ts
+++ b/src/Utils/Logger.ts
@@ -81,7 +81,7 @@ export class Logger {
 
   private write(message: string, level: LogLevel, ...args: any[]): void {
     const message = `${this.formatHeader(level)} - ${message}`;
-    
+
     if (level <= LogLevel.WARN) {
       // write to stderr for errors and warnings
       // eslint-disable-next-line no-console

--- a/src/Utils/Logger.ts
+++ b/src/Utils/Logger.ts
@@ -80,6 +80,14 @@ export class Logger {
   }
 
   private write(message: string, level: LogLevel, ...args: any[]): void {
+    if (level <= LogLevel.WARN) {
+      // write to stderr for errors and warnings
+      // eslint-disable-next-line no-console
+      console.error(`${this.formatHeader(level)} - ${message}`, ...args);
+
+      return;
+    }
+
     // eslint-disable-next-line no-console
     console.log(`${this.formatHeader(level)} - ${message}`, ...args);
   }


### PR DESCRIPTION
BREAKING CHANGE: Warning logs are now written to stderr instead of stdout.

Supersedes: #611