### PR TITLE
chore: replace yum with dnf for redhat/ubi8

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,11 +97,12 @@ jobs:
       - name: Install dev-deps
         if: startsWith(matrix.os, 'ubuntu')
         run: |
-          sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-          && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
-          && yum install build-essential python3 -y \
-          && yum clean all -y \
-          && rm -rf /var/cache/yum
+          dnf install -y dnf-utils \
+          && dnf config-manager --enable ubi-8-appstream \
+          && dnf config-manager --enable ubi-8-baseos \
+          && dnf install -y python3 gcc gcc-c++ make \
+          && dnf clean all \
+          && rm -rf /var/cache/dnf
 
       - name: Install deps
         uses: ./.github/workflows/composite/npm


### PR DESCRIPTION
the centos/devtoolset-7-toolchain-centos7:7 has been replaced by redhat/ubi8, but install scripts were not. This change replaces the yum commands with a dnf. 