### PR TITLE
fix(github-actions): remove redundant config-manager and clean-all

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,10 +98,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           dnf install -y dnf-utils \
-          && dnf config-manager --enable ubi-8-appstream \
-          && dnf config-manager --enable ubi-8-baseos \
           && dnf install -y python3 gcc gcc-c++ make \
-          && dnf clean all \
           && rm -rf /var/cache/dnf
 
       - name: Install deps


### PR DESCRIPTION
`dnf clean all` command is causing the following error:
```
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

0 files removed
```

let's remove this command for time being and unblock the pipeline