### PR TITLE
feat(repeater): add --keep-alive-msecs flag to control the connection keep-alive duration

### DIFF
--- a/src/Commands/RunRepeater.ts
+++ b/src/Commands/RunRepeater.ts
@@ -154,6 +154,13 @@ export class RunRepeater implements CommandModule {
           return arg;
         }
       })
+      .option('keep-alive-msecs', {
+        requiresArg: false,
+        number: true,
+        default: 30000,
+        describe:
+          'The number of milliseconds to wait before closing the connection. This option is only applicable when using the --experimental-connection-reuse or --ntlm option'
+      })
       .option('proxy-domains-bypass', {
         requiresArg: true,
         array: true,
@@ -255,7 +262,8 @@ export class RunRepeater implements CommandModule {
                 { type: 'application/graphql', allowTruncation: false }
               ],
               proxyDomains: args.proxyDomains as string[],
-              proxyDomainsBypass: args.proxyDomainsBypass as string[]
+              proxyDomainsBypass: args.proxyDomainsBypass as string[],
+              keepAliveMsecs: args.keepAliveMsecs as number
             }
           })
           .register<DefaultRepeaterServerOptions>(

--- a/src/RequestExecutor/HttpRequestExecutor.ts
+++ b/src/RequestExecutor/HttpRequestExecutor.ts
@@ -60,6 +60,7 @@ export class HttpRequestExecutor implements RequestExecutor {
     if (this.options.reuseConnection) {
       const agentOptions: AgentOptions = {
         keepAlive: true,
+        keepAliveMsecs: this.options.keepAliveMsecs,
         maxSockets: 100,
         timeout: this.options.timeout
       };

--- a/src/RequestExecutor/RequestExecutorOptions.ts
+++ b/src/RequestExecutor/RequestExecutorOptions.ts
@@ -16,6 +16,7 @@ export interface RequestExecutorOptions {
   reuseConnection?: boolean;
   proxyDomains?: string[];
   proxyDomainsBypass?: string[];
+  keepAliveMsecs?: number;
 }
 
 export const RequestExecutorOptions: unique symbol = Symbol(


### PR DESCRIPTION
experimental, do not merge
