### PR TITLE
fix(pkg): add rotating-file-stream to asset list

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,8 @@
       "./node_modules/@neuralegion/os-service/prebuilds/win32-*/@neuralegion+os-service.abi115.node",
       "./node_modules/@neuralegion/raw-socket/prebuilds/win32-*/@neuralegion+raw-socket.abi115.node",
       "./node_modules/@neuralegion/raw-socket/prebuilds/linux-x64/@neuralegion+raw-socket.abi115.glibc.node",
-      "./node_modules/@neuralegion/raw-socket/prebuilds/darwin-x64+arm64/@neuralegion+raw-socket.abi115.node"
+      "./node_modules/@neuralegion/raw-socket/prebuilds/darwin-x64+arm64/@neuralegion+raw-socket.abi115.node",
+      "./node_modules/rotating-file-stream/**"
     ],
     "targets": [
       "node20-linux-x64",


### PR DESCRIPTION
the rotating-file-stream use ESM import system while cli app uses CommonJS. In order to be able to use rotating-file-stream we need to add it to the asset list.