### PR TITLE
refactor(scan): replace deprecated attack parameter locations in RestScans configuration

### DIFF
--- a/src/Scan/RestScans.ts
+++ b/src/Scan/RestScans.ts
@@ -177,42 +177,42 @@ export class RestScans implements Scans {
   ): Omit<ScanConfig, 'headers'> {
     if (
       scanConfig.attackParamLocations?.includes(
-        AttackParamLocation.ARTIFICIAL_FRAGMENT
+        AttackParamLocation.ARTIFICAL_FRAGMENT
       )
     ) {
       scanConfig.attackParamLocations = scanConfig.attackParamLocations.filter(
-        (loc) => loc !== AttackParamLocation.ARTIFICIAL_FRAGMENT
+        (loc) => loc !== AttackParamLocation.ARTIFICAL_FRAGMENT
       );
 
       if (
         !scanConfig.attackParamLocations?.includes(
-          AttackParamLocation.ARTIFICAL_FRAGMENT
+          AttackParamLocation.ARTIFICIAL_FRAGMENT
         )
       ) {
         scanConfig.attackParamLocations = [
           ...scanConfig.attackParamLocations,
-          AttackParamLocation.ARTIFICAL_FRAGMENT
+          AttackParamLocation.ARTIFICIAL_FRAGMENT
         ];
       }
     }
 
     if (
       scanConfig.attackParamLocations?.includes(
-        AttackParamLocation.ARTIFICIAL_QUERY
+        AttackParamLocation.ARTIFICAL_QUERY
       )
     ) {
       scanConfig.attackParamLocations = scanConfig.attackParamLocations.filter(
-        (loc) => loc !== AttackParamLocation.ARTIFICIAL_QUERY
+        (loc) => loc !== AttackParamLocation.ARTIFICAL_QUERY
       );
 
       if (
         !scanConfig.attackParamLocations?.includes(
-          AttackParamLocation.ARTIFICAL_QUERY
+          AttackParamLocation.ARTIFICIAL_QUERY
         )
       ) {
         scanConfig.attackParamLocations = [
           ...scanConfig.attackParamLocations,
-          AttackParamLocation.ARTIFICAL_QUERY
+          AttackParamLocation.ARTIFICIAL_QUERY
         ];
       }
     }

--- a/src/Scan/RestScans.ts
+++ b/src/Scan/RestScans.ts
@@ -7,7 +7,8 @@ import {
   SourceType,
   StorageFile,
   ATTACK_PARAM_LOCATIONS_DEFAULT,
-  ScanCreateResponse
+  ScanCreateResponse,
+  AttackParamLocation
 } from './Scans';
 import { CliInfo } from '../Config';
 import { ProxyFactory } from '../Utils';
@@ -100,9 +101,10 @@ export class RestScans implements Scans {
     }
   > {
     const config = await this.applyDefaultSettings(rest);
+    const updatedConfig = this.replaceDeprecatedAttackParamLocations(config);
 
     return {
-      ...config,
+      ...updatedConfig,
       info: {
         source: 'cli',
         client: {
@@ -168,5 +170,53 @@ export class RestScans implements Scans {
       discoveryTypes,
       exclusions
     };
+  }
+
+  private replaceDeprecatedAttackParamLocations(
+    scanConfig: Omit<ScanConfig, 'headers'>
+  ): Omit<ScanConfig, 'headers'> {
+    if (
+      scanConfig.attackParamLocations?.includes(
+        AttackParamLocation.ARTIFICIAL_FRAGMENT
+      )
+    ) {
+      scanConfig.attackParamLocations = scanConfig.attackParamLocations.filter(
+        (loc) => loc !== AttackParamLocation.ARTIFICIAL_FRAGMENT
+      );
+
+      if (
+        !scanConfig.attackParamLocations?.includes(
+          AttackParamLocation.ARTIFICAL_FRAGMENT
+        )
+      ) {
+        scanConfig.attackParamLocations = [
+          ...scanConfig.attackParamLocations,
+          AttackParamLocation.ARTIFICAL_FRAGMENT
+        ];
+      }
+    }
+
+    if (
+      scanConfig.attackParamLocations?.includes(
+        AttackParamLocation.ARTIFICIAL_QUERY
+      )
+    ) {
+      scanConfig.attackParamLocations = scanConfig.attackParamLocations.filter(
+        (loc) => loc !== AttackParamLocation.ARTIFICIAL_QUERY
+      );
+
+      if (
+        !scanConfig.attackParamLocations?.includes(
+          AttackParamLocation.ARTIFICAL_QUERY
+        )
+      ) {
+        scanConfig.attackParamLocations = [
+          ...scanConfig.attackParamLocations,
+          AttackParamLocation.ARTIFICAL_QUERY
+        ];
+      }
+    }
+
+    return scanConfig;
   }
 }

--- a/src/Scan/Scans.ts
+++ b/src/Scan/Scans.ts
@@ -7,8 +7,10 @@ export enum Discovery {
 }
 
 export enum AttackParamLocation {
-  ARTIFICAL_FRAGMENT = 'artifical-fragment',
-  ARTIFICAL_QUERY = 'artifical-query',
+  ARTIFICAL_FRAGMENT = 'artifical-fragment', // deprecated, use ARTIFICIAL_FRAGMENT instead
+  ARTIFICAL_QUERY = 'artifical-query', // deprecated, use ARTIFICIAL_QUERY instead
+  ARTIFICIAL_FRAGMENT = 'artificial-fragment',
+  ARTIFICIAL_QUERY = 'artificial-query',
   BODY = 'body',
   FRAGMENT = 'fragment',
   HEADER = 'header',


### PR DESCRIPTION
There are 2 mistyped attack params:
* artifical-fragment
* artifical-query

But it's not accidental, because Scan API used to require exactly these mistyped params.
To improve this, we amended our API to accept amended values. In this change, we are
adding support to amended values:

```
  ARTIFICAL_FRAGMENT = 'artifical-fragment', // deprecated, use ARTIFICIAL_FRAGMENT instead
  ARTIFICAL_QUERY = 'artifical-query', // deprecated, use ARTIFICIAL_QUERY instead
  ARTIFICIAL_FRAGMENT = 'artificial-fragment',
  ARTIFICIAL_QUERY = 'artificial-query',
  ```

Then if users are using incorrect ones, replace them to amended ones that API requires.