### PR TITLE
feat: multiple certificates per port number of host

### DIFF
--- a/src/Commands/RunRepeater.ts
+++ b/src/Commands/RunRepeater.ts
@@ -82,11 +82,11 @@ export class RunRepeater implements CommandModule {
         array: true,
         string: true,
         describe:
-          'The certificate must be in PKCS, or PEM format. Example: {"hostname": "example.com", "path": "./example.pem", "passphrase": "pa$$word"}.',
+          'The certificate must be in PKCS, or PEM format. Example: {"hostname": "example.com", "path": "./example.pem", "passphrase": "pa$$word", "port": "1234"}.',
         coerce(args: string[]): Cert[] {
           return args
             .map((arg: string) => JSON.parse(arg))
-            .map(({ path, hostname, passphrase }: Cert) => {
+            .map(({ path, hostname, passphrase, port }: Cert) => {
               if (!path) {
                 logger.error(
                   'Error during "repeater": Specify the path to your client certificate file.'
@@ -104,7 +104,8 @@ export class RunRepeater implements CommandModule {
               return {
                 hostname,
                 passphrase,
-                path: normalize(path)
+                path: normalize(path),
+                port
               };
             });
         }

--- a/src/RequestExecutor/Request.spec.ts
+++ b/src/RequestExecutor/Request.spec.ts
@@ -183,4 +183,103 @@ describe('Request', () => {
       expect(request2.pfx).toEqual(cert2Content);
     });
   });
+
+  it('should load different certs for default ports', async () => {
+    const request1 = new Request({
+      url: 'https://foo.bar:80',
+      protocol: Protocol.HTTP
+    });
+
+    const request2 = new Request({
+      url: 'https://foo.bar:443',
+      protocol: Protocol.HTTP
+    });
+
+    const cert1 = {
+      path: '~/cert1.pfx',
+      hostname: 'foo.bar',
+      port: '80'
+    };
+
+    const cert2 = {
+      path: '~/cert2.pfx',
+      hostname: 'foo.bar',
+      port: '443'
+    };
+
+    const cert1Content = Buffer.from('cert1', 'utf8');
+    const cert2Content = Buffer.from('cert2', 'utf8');
+
+    //arrange:mock
+    readFileMock.mockImplementation((filePath) => {
+      switch (filePath) {
+        case cert1.path:
+          return Promise.resolve(cert1Content);
+        case cert2.path:
+          return Promise.resolve(cert2Content);
+        default:
+          return Promise.reject(new Error('no such file'));
+      }
+    });
+
+    //act
+    await request1.setCerts([cert1, cert2]);
+    await request2.setCerts([cert1, cert2]);
+
+    //assert
+    expect(request1.pfx).toBeTruthy();
+    expect(request1.pfx).toEqual(cert1Content);
+
+    expect(request2.pfx).toBeTruthy();
+    expect(request2.pfx).toEqual(cert2Content);
+  });
+
+  it('should load different certs for default and specific port', async () => {
+    const request1 = new Request({
+      url: 'https://foo.bar:8080',
+      protocol: Protocol.HTTP
+    });
+
+    const request2 = new Request({
+      url: 'https://foo.bar',
+      protocol: Protocol.HTTP
+    });
+
+    const cert1 = {
+      path: '~/cert1.pfx',
+      hostname: 'foo.bar',
+      port: '8080'
+    };
+
+    const cert2 = {
+      path: '~/cert2.pfx',
+      hostname: 'foo.bar'
+    };
+
+    const cert1Content = Buffer.from('cert1', 'utf8');
+    const cert2Content = Buffer.from('cert2', 'utf8');
+
+    //arrange:mock
+    readFileMock.mockImplementation((filePath) => {
+      switch (filePath) {
+        case cert1.path:
+          return Promise.resolve(cert1Content);
+        case cert2.path:
+          return Promise.resolve(cert2Content);
+        default:
+          return Promise.reject(new Error('no such file'));
+      }
+    });
+
+    //act
+    await request1.setCerts([cert1, cert2]);
+    await request2.setCerts([cert1, cert2]);
+
+    //assert
+    expect(request1.pfx).toBeTruthy();
+    expect(request1.pfx).toEqual(cert1Content);
+
+    expect(request2.pfx).toBeTruthy();
+    expect(request2.pfx).toEqual(cert2Content);
+  });
 });

--- a/src/RequestExecutor/Request.spec.ts
+++ b/src/RequestExecutor/Request.spec.ts
@@ -186,7 +186,7 @@ describe('Request', () => {
 
   it('should load different certs for default ports', async () => {
     const request1 = new Request({
-      url: 'https://foo.bar:80',
+      url: 'http://foo.bar:80',
       protocol: Protocol.HTTP
     });
 

--- a/src/RequestExecutor/Request.spec.ts
+++ b/src/RequestExecutor/Request.spec.ts
@@ -132,5 +132,55 @@ describe('Request', () => {
         host: 'example.com, example1.com'
       });
     });
+
+    it('should load different certs per matching port', async () => {
+      const request1 = new Request({
+        url: 'https://foo.bar:8080',
+        protocol: Protocol.HTTP
+      });
+
+      const request2 = new Request({
+        url: 'https://foo.bar:1234',
+        protocol: Protocol.HTTP
+      });
+
+      const cert1 = {
+        path: '~/cert1.pfx',
+        hostname: 'foo.bar',
+        port: '8080'
+      };
+
+      const cert2 = {
+        path: '~/cert2.pfx',
+        hostname: 'foo.bar',
+        port: '1234'
+      };
+
+      const cert1Content = Buffer.from('cert1', 'utf8');
+      const cert2Content = Buffer.from('cert2', 'utf8');
+
+      //arrange:mock
+      readFileMock.mockImplementation((filePath) => {
+        switch (filePath) {
+          case cert1.path:
+            return Promise.resolve(cert1Content);
+          case cert2.path:
+            return Promise.resolve(cert2Content);
+          default:
+            return Promise.reject(new Error('no such file'));
+        }
+      });
+
+      //act
+      await request1.setCerts([cert1, cert2]);
+      await request2.setCerts([cert1, cert2]);
+
+      //assert
+      expect(request1.pfx).toBeTruthy();
+      expect(request1.pfx).toEqual(cert1Content);
+
+      expect(request2.pfx).toBeTruthy();
+      expect(request2.pfx).toEqual(cert2Content);
+    });
   });
 });

--- a/src/RequestExecutor/Request.ts
+++ b/src/RequestExecutor/Request.ts
@@ -157,17 +157,27 @@ export class Request {
   }
 
   public async setCerts(certs: Cert[]): Promise<void> {
-    const { hostname, port } = new URL(this.url);
+    const url = new URL(this.url);
+
+    const port =
+      url.port ||
+      (url.protocol === 'http:'
+        ? '80'
+        : url.protocol === 'https:'
+        ? '443'
+        : '');
 
     const cert: Cert | undefined = certs.find((x) =>
-      this.matchHostnameAndPort(hostname, port, x)
+      this.matchHostnameAndPort(url.hostname, port, x)
     );
 
     if (!cert) {
-      logger.warn(`Warning: certificate for ${hostname} not found.`);
+      logger.warn(`Warning: certificate for ${url.hostname} not found.`);
 
       return;
     }
+
+    logger.trace(`Using certificate for ${url}`, cert);
 
     await this.loadCert(cert);
   }

--- a/src/RequestExecutor/Request.ts
+++ b/src/RequestExecutor/Request.ts
@@ -25,6 +25,7 @@ export interface Cert {
   path: string;
   hostname: string;
   passphrase?: string;
+  port?: string;
 }
 
 export class Request {
@@ -156,10 +157,10 @@ export class Request {
   }
 
   public async setCerts(certs: Cert[]): Promise<void> {
-    const { hostname } = new URL(this.url);
+    const { hostname, port } = new URL(this.url);
 
     const cert: Cert | undefined = certs.find((x) =>
-      this.matchHostname(hostname, x.hostname)
+      this.matchHostnameAndPort(hostname, port, x)
     );
 
     if (!cert) {
@@ -239,10 +240,17 @@ export class Request {
     }
   }
 
-  private matchHostname(hostname: string, wildcard: string): boolean {
-    return (
-      wildcard === hostname || Helpers.wildcardToRegExp(wildcard).test(hostname)
-    );
+  private matchHostnameAndPort(
+    hostname: string,
+    port: string,
+    cert: Cert
+  ): boolean {
+    const hostNameMatch =
+      cert.hostname === hostname ||
+      Helpers.wildcardToRegExp(cert.hostname).test(hostname);
+    const portMatch = cert.port === port;
+
+    return cert.port ? hostNameMatch && portMatch : hostNameMatch;
   }
 
   private assertPassphrase(

--- a/src/RequestExecutor/Request.ts
+++ b/src/RequestExecutor/Request.ts
@@ -263,7 +263,12 @@ export class Request {
       return false;
     }
 
-    return !!cert.port || cert.port === port;
+    if (!cert.port) {
+      // ADHOC: hostNameMatch has been checked above and it's true
+      return true;
+    }
+
+    return cert.port === port;
   }
 
   private assertPassphrase(

--- a/src/RequestExecutor/Request.ts
+++ b/src/RequestExecutor/Request.ts
@@ -258,9 +258,12 @@ export class Request {
     const hostNameMatch =
       cert.hostname === hostname ||
       Helpers.wildcardToRegExp(cert.hostname).test(hostname);
-    const portMatch = cert.port === port;
 
-    return cert.port ? hostNameMatch && portMatch : hostNameMatch;
+    if (!hostNameMatch) {
+      return false;
+    }
+
+    return !!cert.port || cert.port === port;
   }
 
   private assertPassphrase(


### PR DESCRIPTION
Allow users to set multiple certificates attached to port number of host. For this users must add the `port` param to Cert object:
```
{
    "path": "/path/to/certificates/client.pfx",
    "hostname": "brightsec.com",
    "passphrase": "password", 
    "port":"8443"     <---- port number
}
```

The feature does not work unless users explicitly set port number. When no port number is specified, the logic will fallback to existing only host based checks.