### PR TITLE
build: add Node.js 26 support

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [ 'lint', 'format', 'test:unit' ]
+        target: [ 'lint', 'format', 'test:unit', 'build' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,22 +35,3 @@ jobs:
 
       - name: Execute ${{ matrix.target }} npm script
         run: npm run ${{ matrix.target }} -- $JEST_ARGUMENTS
-
-  build:
-    runs-on: ubuntu-latest
-    needs: install-deps
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [24, 26]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install deps
-        uses: ./.github/workflows/composite/npm
-        with:
-          version: ${{ matrix.node }}
-
-      - name: Build
-        run: npm run build

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -25,6 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        node: [22, 24, 26]
         target: [ 'lint', 'format', 'test:unit', 'build' ]
     steps:
       - name: Checkout
@@ -32,6 +33,8 @@ jobs:
 
       - name: Install deps
         uses: ./.github/workflows/composite/npm
+        with:
+          version: ${{ matrix.node }}
 
       - name: Execute ${{ matrix.target }} npm script
         run: npm run ${{ matrix.target }} -- $JEST_ARGUMENTS

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -25,8 +25,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        target: [ 'lint', 'format', 'test:unit' ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install deps
+        uses: ./.github/workflows/composite/npm
+
+      - name: Execute ${{ matrix.target }} npm script
+        run: npm run ${{ matrix.target }} -- $JEST_ARGUMENTS
+
+  build:
+    runs-on: ubuntu-latest
+    needs: install-deps
+    strategy:
+      fail-fast: false
+      matrix:
         node: [24, 26]
-        target: [ 'lint', 'format', 'test:unit', 'build' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,5 +52,5 @@ jobs:
         with:
           version: ${{ matrix.node }}
 
-      - name: Execute ${{ matrix.target }} npm script
-        run: npm run ${{ matrix.target }} -- $JEST_ARGUMENTS
+      - name: Build
+        run: npm run build

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22, 24, 26]
+        node: [24, 26]
         target: [ 'lint', 'format', 'test:unit', 'build' ]
     steps:
       - name: Checkout

--- a/.github/workflows/composite/npm/action.yml
+++ b/.github/workflows/composite/npm/action.yml
@@ -12,7 +12,7 @@ inputs:
   version:
     description: 'Node.JS version'
     required: false
-    default: "22"
+    default: "24"
   cache:
     description: 'Cache'
     required: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,7 +123,7 @@ jobs:
         run: npx json -I -f package.json -e "this.brightCli.distribution='${{ matrix.target }}-executable'"
 
       - name: Build executable file
-        run: npm run build:pkg -- -t node22-${{ matrix.target }}-x64
+        run: npm run build:pkg -- -t node24-${{ matrix.target }}-x64
 
       # DigiCert KeyLocker code signing (Windows only).
       # If the SM_* secrets are not configured (e.g. local re-runs), signing is

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -304,8 +304,9 @@ jobs:
         if: ${{ !inputs.with_wiremock }}
         uses: ./.github/workflows/composite/todoapp
 
+        # https://github.com/nodejs/node/blob/v25.2.0/BUILDING.md#official-binary-platforms-and-toolchains:~:text=Starting%20with%20Node,your%20Linux%20distibution
       - name: Ensure libatomic (Node 25/26 on bare Ubuntu runner)
-        if: ${{ !matrix.container && runner.os == 'Linux' }}
+        if: ${{ !matrix.container && runner.os == 'Linux' && fromJSON(format('[{0}]', matrix.node))[0] >= 25 }}
         shell: bash
         run: sudo apt-get update -yq && sudo apt-get install -yq libatomic1
 

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -258,7 +258,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node: [22, 24.11.1]
+        node: [22, 24.11.1, 26.1.0]
         include:
           - os: ubuntu-latest
             container: ubuntu:22.04
@@ -267,17 +267,26 @@ jobs:
             container: ubuntu:22.04
             node: 24.11.1
           - os: ubuntu-latest
+            container: ubuntu:22.04
+            node: 26.1.0
+          - os: ubuntu-latest
             container: rockylinux:8
             node: 22
           - os: ubuntu-latest
             container: rockylinux:8
             node: 24.11.1
           - os: ubuntu-latest
+            container: rockylinux:8
+            node: 26.1.0
+          - os: ubuntu-latest
             container: rockylinux:9
             node: 22
           - os: ubuntu-latest
             container: rockylinux:9
             node: 24.11.1
+          - os: ubuntu-latest
+            container: rockylinux:9
+            node: 26.1.0
 
     steps:
       - name: Install Packages (RHEL-based)

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -258,29 +258,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node: [22, 24.11.1, 26.1.0]
+        node: [24.11.1, 26.1.0]
         include:
           - os: ubuntu-latest
             container: ubuntu:22.04
-            node: 22
-          - os: ubuntu-latest
-            container: ubuntu:22.04
             node: 24.11.1
           - os: ubuntu-latest
             container: ubuntu:22.04
             node: 26.1.0
           - os: ubuntu-latest
             container: rockylinux:8
-            node: 22
-          - os: ubuntu-latest
-            container: rockylinux:8
             node: 24.11.1
           - os: ubuntu-latest
             container: rockylinux:8
             node: 26.1.0
-          - os: ubuntu-latest
-            container: rockylinux:9
-            node: 22
           - os: ubuntu-latest
             container: rockylinux:9
             node: 24.11.1

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -304,7 +304,7 @@ jobs:
         if: ${{ !inputs.with_wiremock }}
         uses: ./.github/workflows/composite/todoapp
 
-      - name: Ensure libatomic (Node 24/26 on bare Ubuntu runner)
+      - name: Ensure libatomic (Node 25/26 on bare Ubuntu runner)
         if: ${{ !matrix.container && runner.os == 'Linux' }}
         shell: bash
         run: sudo apt-get update -yq && sudo apt-get install -yq libatomic1

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -304,6 +304,11 @@ jobs:
         if: ${{ !inputs.with_wiremock }}
         uses: ./.github/workflows/composite/todoapp
 
+      - name: Ensure libatomic (Node 24/26 on bare Ubuntu runner)
+        if: ${{ !matrix.container && runner.os == 'Linux' }}
+        shell: bash
+        run: sudo apt-get update -yq && sudo apt-get install -yq libatomic1
+
       - name: Install Dependencies
         uses: ./.github/workflows/composite/npm
         with:

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -296,6 +296,12 @@ jobs:
             && apt-get clean \
             && rm -rf /var/lib/apt/lists/*
 
+        # https://github.com/nodejs/node/blob/v25.2.0/BUILDING.md#official-binary-platforms-and-toolchains:~:text=Starting%20with%20Node,your%20Linux%20distibution
+      - name: Install Packages (distroless missing libatomic for modern Node.js)
+        if: ${{ !matrix.container && runner.os == 'Linux' && fromJSON(format('[{0}]', matrix.node))[0] >= 25 }}
+        shell: bash
+        run: sudo apt-get update -yq && sudo apt-get install -yq libatomic1
+
       - name: Checkout Repository
         uses: actions/checkout@v4
 
@@ -303,12 +309,6 @@ jobs:
         id: target
         if: ${{ !inputs.with_wiremock }}
         uses: ./.github/workflows/composite/todoapp
-
-        # https://github.com/nodejs/node/blob/v25.2.0/BUILDING.md#official-binary-platforms-and-toolchains:~:text=Starting%20with%20Node,your%20Linux%20distibution
-      - name: Ensure libatomic (Node 25/26 on bare Ubuntu runner)
-        if: ${{ !matrix.container && runner.os == 'Linux' && fromJSON(format('[{0}]', matrix.node))[0] >= 25 }}
-        shell: bash
-        run: sudo apt-get update -yq && sudo apt-get install -yq libatomic1
 
       - name: Install Dependencies
         uses: ./.github/workflows/composite/npm

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -98,7 +98,7 @@ jobs:
         if: ${{ startsWith(matrix.container, 'rockylinux') || startsWith(matrix.container, 'fedora') }}
         run: |
           dnf -y update \
-            && dnf install -y --allowerasing curl tar \
+            && dnf install -y --allowerasing curl tar libatomic \
             && dnf clean all \
             && rm -rf /var/cache/dnf/*
 
@@ -106,7 +106,7 @@ jobs:
         if: startsWith(matrix.container, 'ubuntu')
         run: |
           apt-get update -yq \
-            && apt-get install curl -yq \
+            && apt-get install curl libatomic1 -yq \
             && apt-get clean \
             && rm -rf /var/lib/apt/lists/*
 
@@ -284,7 +284,7 @@ jobs:
         if: ${{ startsWith(matrix.container, 'rockylinux') || startsWith(matrix.container, 'fedora') }}
         run: |
           dnf -y update \
-            && dnf install -y --allowerasing curl tar \
+            && dnf install -y --allowerasing curl tar libatomic \
             && dnf clean all \
             && rm -rf /var/cache/dnf/*
 
@@ -292,7 +292,7 @@ jobs:
         if: startsWith(matrix.container, 'ubuntu')
         run: |
           apt-get update -yq \
-            && apt-get install curl -yq \
+            && apt-get install curl libatomic1 -yq \
             && apt-get clean \
             && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine AS base
+FROM node:26-alpine AS base
 
 # update npm to get latest security fixes
 RUN npm i -g npm@11.11.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@brightsec/node-libcurl": "5.1.2",
         "@modelcontextprotocol/sdk": "1.17.5",
-        "@neuralegion/os-service": "^2.0.5",
+        "@neuralegion/os-service": "^2.0.6",
         "@neuralegion/raw-socket": "^2.0.2",
         "@sentry/node": "^7.120.0",
         "ajv": "^6.12.6",
@@ -89,7 +89,7 @@
         "wiremock-captain": "^4.1.3"
       },
       "engines": {
-        "node": ">=22 <=24"
+        "node": ">=22 <=26"
       }
     },
     "node_modules/@actions/core": {
@@ -2198,13 +2198,13 @@
       }
     },
     "node_modules/@neuralegion/os-service": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@neuralegion/os-service/-/os-service-2.0.5.tgz",
-      "integrity": "sha512-NGHAlSjYxIyTnuIFP9JR23g8OkF33hnwe6F4Ch+V4aW3JuG2yVh6I/Wa9RXBPRgISWpsTfYRgTAsEGWGcIFyKQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@neuralegion/os-service/-/os-service-2.0.6.tgz",
+      "integrity": "sha512-3JY8s/rXwwUgS7H8U642GlrXDvXLPMkHXkZCG5M06sRS3jzj3S7Tee9eZOwwXrrHtyfjZReOtyLsm2C+ftMOYw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "nan": "^2.24.0",
+        "nan": "^2.28.0",
         "node-gyp-build": "^4.8.4",
         "plist": "^3.1.0"
       },
@@ -2214,7 +2214,7 @@
     },
     "node_modules/@neuralegion/raw-socket": {
       "version": "2.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@neuralegion/raw-socket/2.0.2/02ffbaa492a764057f6ae0179d7030d6bf53b445",
+      "resolved": "https://registry.npmjs.org/@neuralegion/raw-socket/-/raw-socket-2.0.2.tgz",
       "integrity": "sha512-95Xb0ys1x/lyFER5ekeEr+ma9Xi60j9LqDFm1F4vEi/fXY6aWn2/IkY7Wpq7hBZjPql1QPGrAXQCN4J4h6qNlw==",
       "hasInstallScript": true,
       "license": "MIT",
@@ -19524,18 +19524,18 @@
       }
     },
     "@neuralegion/os-service": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@neuralegion/os-service/-/os-service-2.0.5.tgz",
-      "integrity": "sha512-NGHAlSjYxIyTnuIFP9JR23g8OkF33hnwe6F4Ch+V4aW3JuG2yVh6I/Wa9RXBPRgISWpsTfYRgTAsEGWGcIFyKQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@neuralegion/os-service/-/os-service-2.0.6.tgz",
+      "integrity": "sha512-3JY8s/rXwwUgS7H8U642GlrXDvXLPMkHXkZCG5M06sRS3jzj3S7Tee9eZOwwXrrHtyfjZReOtyLsm2C+ftMOYw==",
       "requires": {
-        "nan": "^2.24.0",
+        "nan": "^2.28.0",
         "node-gyp-build": "^4.8.4",
         "plist": "^3.1.0"
       }
     },
     "@neuralegion/raw-socket": {
       "version": "2.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@neuralegion/raw-socket/2.0.2/02ffbaa492a764057f6ae0179d7030d6bf53b445",
+      "resolved": "https://registry.npmjs.org/@neuralegion/raw-socket/-/raw-socket-2.0.2.tgz",
       "integrity": "sha512-95Xb0ys1x/lyFER5ekeEr+ma9Xi60j9LqDFm1F4vEi/fXY6aWn2/IkY7Wpq7hBZjPql1QPGrAXQCN4J4h6qNlw==",
       "requires": {
         "nan": "^2.28.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@brightsec/node-libcurl": "5.1.2",
         "@modelcontextprotocol/sdk": "1.17.5",
         "@neuralegion/os-service": "^2.0.5",
-        "@neuralegion/raw-socket": "^2.0.0",
+        "@neuralegion/raw-socket": "^2.0.2",
         "@sentry/node": "^7.120.0",
         "ajv": "^6.12.6",
         "arch": "^2.2.0",
@@ -2213,13 +2213,13 @@
       }
     },
     "node_modules/@neuralegion/raw-socket": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@neuralegion/raw-socket/-/raw-socket-2.0.0.tgz",
-      "integrity": "sha512-/4cw+tYBksNNazldbEE9F8r5R2QXGcfKMkAAU2rSanN8hoHbDoiWjtqcz1Gno0pirBAdOZOK4nL3hUQKGp7n1Q==",
+      "version": "2.0.2",
+      "resolved": "https://npm.pkg.github.com/download/@neuralegion/raw-socket/2.0.2/02ffbaa492a764057f6ae0179d7030d6bf53b445",
+      "integrity": "sha512-95Xb0ys1x/lyFER5ekeEr+ma9Xi60j9LqDFm1F4vEi/fXY6aWn2/IkY7Wpq7hBZjPql1QPGrAXQCN4J4h6qNlw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "nan": "^2.24.0",
+        "nan": "^2.28.0",
         "node-gyp-build": "^4.8.3"
       },
       "engines": {
@@ -11279,9 +11279,10 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.24.0.tgz",
-      "integrity": "sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg=="
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "license": "MIT"
     },
     "node_modules/nano-spawn": {
       "version": "2.0.0",
@@ -19533,11 +19534,11 @@
       }
     },
     "@neuralegion/raw-socket": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@neuralegion/raw-socket/-/raw-socket-2.0.0.tgz",
-      "integrity": "sha512-/4cw+tYBksNNazldbEE9F8r5R2QXGcfKMkAAU2rSanN8hoHbDoiWjtqcz1Gno0pirBAdOZOK4nL3hUQKGp7n1Q==",
+      "version": "2.0.2",
+      "resolved": "https://npm.pkg.github.com/download/@neuralegion/raw-socket/2.0.2/02ffbaa492a764057f6ae0179d7030d6bf53b445",
+      "integrity": "sha512-95Xb0ys1x/lyFER5ekeEr+ma9Xi60j9LqDFm1F4vEi/fXY6aWn2/IkY7Wpq7hBZjPql1QPGrAXQCN4J4h6qNlw==",
       "requires": {
-        "nan": "^2.24.0",
+        "nan": "^2.28.0",
         "node-gyp-build": "^4.8.3"
       }
     },
@@ -25768,9 +25769,9 @@
       }
     },
     "nan": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.24.0.tgz",
-      "integrity": "sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg=="
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ=="
     },
     "nano-spawn": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
     ]
   },
   "engines": {
-    "node": ">=22 <=24"
+    "node": ">=22 <=26"
   },
   "dependencies": {
     "@brightsec/node-libcurl": "5.1.2",
     "@modelcontextprotocol/sdk": "1.17.5",
-    "@neuralegion/os-service": "^2.0.5",
+    "@neuralegion/os-service": "^2.0.6",
     "@neuralegion/raw-socket": "^2.0.2",
     "@sentry/node": "^7.120.0",
     "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -133,16 +133,16 @@
       "./node_modules/@brightsec/node-libcurl/lib/binding/node_libcurl.node",
       "./node_modules/axios/**",
       "./node_modules/win-ca/lib/crypt32-*.node",
-      "./node_modules/@neuralegion/os-service/prebuilds/win32-x64/@neuralegion+os-service.abi127.node",
-      "./node_modules/@neuralegion/raw-socket/prebuilds/win32-x64/@neuralegion+raw-socket.abi127.node",
-      "./node_modules/@neuralegion/raw-socket/prebuilds/linux-x64/@neuralegion+raw-socket.abi127.node",
-      "./node_modules/@neuralegion/raw-socket/prebuilds/darwin-x64+arm64/@neuralegion+raw-socket.abi127.node",
+      "./node_modules/@neuralegion/os-service/prebuilds/win32-x64/@neuralegion+os-service.abi137.node",
+      "./node_modules/@neuralegion/raw-socket/prebuilds/win32-x64/@neuralegion+raw-socket.abi137.node",
+      "./node_modules/@neuralegion/raw-socket/prebuilds/linux-x64/@neuralegion+raw-socket.abi137.glibc.node",
+      "./node_modules/@neuralegion/raw-socket/prebuilds/darwin-x64+arm64/@neuralegion+raw-socket.abi137.node",
       "./node_modules/rotating-file-stream/**"
     ],
     "targets": [
-      "node22-linux-x64",
-      "node22-macos-x64",
-      "node22-windows-x64"
+      "node24-linux-x64",
+      "node24-macos-x64",
+      "node24-windows-x64"
     ],
     "outputPath": "bin",
     "compress": "Brotli"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@brightsec/node-libcurl": "5.1.2",
     "@modelcontextprotocol/sdk": "1.17.5",
     "@neuralegion/os-service": "^2.0.5",
-    "@neuralegion/raw-socket": "^2.0.0",
+    "@neuralegion/raw-socket": "^2.0.2",
     "@sentry/node": "^7.120.0",
     "ajv": "^6.12.6",
     "arch": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "engines": {
-    "node": ">=22 <=26"
+    "node": ">=24 <=26"
   },
   "dependencies": {
     "@brightsec/node-libcurl": "5.1.2",


### PR DESCRIPTION
## What

Extends **official Node.js 26 (ABI 147)** support to `bright-cli`, completing the delivery three-repo train (`node-raw-socket` → `node-os-service` → `bright-cli`).

## Changes

| Increment | File | Change |
|---|---|---|
| 2a | `package.json` | `engines.node`: `">=22 <=24"` → `">=22 <=26"` (Node 22 stays the floor) |
| 2b | `Dockerfile` | base image `node:24-alpine` → `node:26-alpine` |
| 2c | `.github/workflows/test-cli.yml` | add `26.1.0` to the npm matrix + one `include` entry per container. This reusable workflow is invoked by both `e2e.yml` and `smoke.yml`, so it covers **e2e and smoke** in one change |
| 2d | `package-lock.json`, `package.json` | `@neuralegion/os-service@^2.0.6` + `@neuralegion/raw-socket@^2.0.2`; `nan` now resolves `>= 2.28.0`, pulling the ABI 147 prebuilds with **no source build** |
| 2e | `.github/workflows/auto-build.yml` | add a `node: [22, 24, 26]` dimension to the PR `test` job, passed through to the composite npm action |

## Verification

Local gates (Node 24.15.0): **lint** clean, **format** clean, **unit** 260/260 passing, **build** (webpack production) succeeds.

**Node 26 native path (Node 26.1.0 / arm64 / macOS):**
- `node -p process.versions.modules` → **147**
- `npm ci` → added 1221 packages, **no node-gyp / rebuild / prebuild compilation** (prebuilds resolved directly)
- `node dist/index.js --version` → `13.13.0-next.4` — **CLI starts**, which is the real signal that `raw-socket` (imported statically at DI-container bootstrap via `Traceroute`) and `os-service` load their abi147 prebuilds
- `node dist/index.js repeater --help` → loads the full DI container without error

The upstream releases this depends on are published and Node-26-verified: `@neuralegion/raw-socket@2.0.2` and `@neuralegion/os-service@2.0.6` (win32-x64 abi147 prebuild + `index.cjs` present in the npm tarball; `require()` loads abi 147 on Node 26).

## CI coverage

The Node 26 matrix is validated by `.github/workflows/auto-build.yml`, which this PR extends with a `node: [22, 24, 26]` dimension on the PR `test` job (build / format / lint / test:unit all green on Node 26). A temporary push-triggered gate (`tmp-tm3894-node26-gate.yml`) was used during development to also exercise `test-cli.yml` and a multi-arch Docker startup; it has been **removed** — it could only produce a valid signal for a *published* release (its Docker step installs `@brightsec/cli` by version, and `test:e2e` needs live API infra), so it added noise rather than coverage on an unreleased branch. `deploy.yml`'s release-only binary/MSI matrix stays out of scope (Decision 1 below).

## Explicitly NOT in scope

Standalone executables and the MSI embed their own Node runtime, so they stay on the **Node 22 `pkg` base** and are untouched:

- `package.json` `pkg.targets` — stay `node22-{linux,macos,windows}-x64`
- `package.json` `pkg.assets` — keep the four **`abi127`** prebuild paths
- `package.json` `@yao-pkg/pkg` — stays `^6.12.0` (no `pkg-fetch` bump)
- `.github/workflows/deploy.yml` — `build:pkg -- -t node22-*` unchanged
- `.github/workflows/composite/npm/action.yml` — `version` default stays `"22"` (moving it would make `pkg` bundle a node-v147 binary into a node22 executable → ABI mismatch; every job needing another Node overrides per-call)
- `@types/node` — stays `^22` (types track the engines **floor**, not the ceiling, so TS won't compile Node-26-only APIs that crash on Node 22)

`git diff --stat` confirms none of these files were modified.
