### PR TITLE
fix(sentry): ignore inactive repeater alerts and stabilize matching

### DIFF
--- a/src/Config/CliBuilder.ts
+++ b/src/Config/CliBuilder.ts
@@ -230,7 +230,8 @@ export class CliBuilder {
       attachStacktrace: true,
       release: process.env.VERSION,
       ignoreErrors: [
-        /^The Repeater ID [\w]+ specified is currently being used by another Repeater./
+        /The Repeater ID [\w]+ specified is currently being used by another Repeater\./,
+        /The Repeater ID [\w]+ is inactive\./
       ],
       beforeSend(event) {
         if (event.contexts.args) {


### PR DESCRIPTION
## What

Extends the Sentry `ignoreErrors` filter in `CliBuilder.ts` so both operational Repeater messages are suppressed and grouped consistently:

```ts
ignoreErrors: [
  /The Repeater ID [\w]+ specified is currently being used by another Repeater\./,
  /The Repeater ID [\w]+ is inactive\./
]
```

## Why

These messages arrive from the backend over the socket and are forwarded verbatim to Sentry via `captureMessage(event.message)` in `DefaultRepeaterServer.ts`. Because each message embeds a randomly generated Repeater ID, Sentry's default grouping is unstable — the same underlying error gets split into multiple issues (e.g. [4632315198](https://neuralegion.sentry.io/issues/4632315198) and [5182826264](https://neuralegion.sentry.io/issues/5182826264)), with the primary title and title swapped between them.

The previous filter (added in #771) had two gaps:

- The `The Repeater ID <id> is inactive.` message had no rule at all, so it was never filtered.
- The `currently being used by another Repeater` pattern was anchored with `^`, which the variable ID token can defeat once Sentry rewrites the message into a title, so it could miss even that case.

This change adds the missing pattern and drops the `^` anchor so both messages are ignored regardless of where the ID appears.

## Note

This only affects new events. The already-registered duplicate issues should be merged/resolved in the Sentry UI.
